### PR TITLE
[#57]feat: 마이페이지 구현 등

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "next": "15.3.1",
         "next-pwa": "^5.6.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2887,7 +2888,7 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4314,7 +4315,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -9623,6 +9624,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "next": "15.3.1",
     "next-pwa": "^5.6.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,21 @@
+// app/profile/page.tsx
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import ProfilePageClient from "@/components/profile/ProfilePageClient";
+
+export const metadata = {
+  title: "마이페이지",
+};
+
+// 서버 컴포넌트
+export default async function ProfilePage() {
+  // 서버에서 인증 확인
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("accessToken");
+
+  if (!accessToken) {
+    redirect("/");
+  }
+
+  return <ProfilePageClient />;
+}

--- a/src/app/profile/update/page.tsx
+++ b/src/app/profile/update/page.tsx
@@ -1,0 +1,21 @@
+// app/profile/update/page.tsx
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import ProfileUpdatePageClient from "@/components/profile/ProfileUpdatePageClient";
+
+export const metadata = {
+  title: "프로필 수정",
+};
+
+// 서버 컴포넌트
+export default async function ProfileUpdatePage() {
+  // 서버에서 인증 확인
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("accessToken");
+
+  if (!accessToken) {
+    redirect("/");
+  }
+
+  return <ProfileUpdatePageClient />;
+}

--- a/src/components/auth/LoginPageClient.tsx
+++ b/src/components/auth/LoginPageClient.tsx
@@ -7,11 +7,13 @@ import Image from "next/image";
 import { useAuth } from "@/hooks/useAuth";
 import { socialLogin } from "@/services/authService";
 import { isPWA, isMobile } from "@/utils/deviceDetection";
+import { useMemberStore } from "@/stores/useMemberStore";
 
 export default function LoginPageClient() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { login } = useAuth();
+  const { fetchMember } = useMemberStore();
   const [isLoading, setIsLoading] = useState(false);
 
   // 브라우저 및 환경 감지 함수들
@@ -272,7 +274,12 @@ export default function LoginPageClient() {
       try {
         const response = await socialLogin(requestData);
 
+        // 로그인 성공 시 토큰 저장
         login(response.accessToken, response.refreshToken);
+
+        // 회원 정보를 zustand store에 저장
+        await fetchMember();
+
         router.push("/transaction/my");
       } catch (error) {
         if (error.message === "존재하지 않는 회원입니다.") {

--- a/src/components/auth/SignUpInfoClient.tsx
+++ b/src/components/auth/SignUpInfoClient.tsx
@@ -336,7 +336,7 @@ export default function SignUpInfoClient() {
             />
             {nameError && (
               <p className="text-red-500 text-xs mt-1">
-                2자 ~ 15자 사이의 한글, 영문으로 입력해주세요
+                2자 ~ 30자 사이의 한글, 영문으로 입력해주세요
               </p>
             )}
           </div>

--- a/src/components/group/GroupInfoPageClient.tsx
+++ b/src/components/group/GroupInfoPageClient.tsx
@@ -4,7 +4,7 @@
 import { useState, useEffect } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { getGroupInfo, leaveGroup, GroupInfo } from "@/services/groupService";
-import { getMember, Member } from "@/services/memberService";
+import { useMemberStore } from "@/stores/useMemberStore";
 import Image from "next/image";
 import TopBar from "@/components/ui/TopBar";
 import BottomBar from "@/components/ui/BottomBar";
@@ -13,13 +13,19 @@ export default function GroupInfoPageClient() {
   const router = useRouter();
   const params = useParams();
   const teamId = params.teamId as string;
+  const { member: memberInfo, fetchMember } = useMemberStore();
 
-  const [memberInfo, setMemberInfo] = useState<Member | null>(null);
   const [groupInfo, setGroupInfo] = useState<GroupInfo | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
   const [showLeaveModal, setShowLeaveModal] = useState(false);
   const [showLeaderSelectModal, setShowLeaderSelectModal] = useState(false);
   const [selectedNewLeader, setSelectedNewLeader] = useState<string>("");
+
+  // 회원 정보가 없으면 가져오기
+  useEffect(() => {
+    if (!memberInfo) {
+      fetchMember();
+    }
+  }, [memberInfo, fetchMember]);
 
   // 그룹 정보 로드
   useEffect(() => {
@@ -31,8 +37,6 @@ export default function GroupInfoPageClient() {
       }
 
       try {
-        setIsLoading(true);
-
         const response = await getGroupInfo(teamId);
 
         setGroupInfo(response);
@@ -40,31 +44,12 @@ export default function GroupInfoPageClient() {
         alert(error || "그룹 정보를 불러올 수 없습니다.");
 
         router.replace("/group");
-      } finally {
-        setIsLoading(false);
-      }
-    }, 100);
-
-    const timeoutId2 = setTimeout(async () => {
-      try {
-        setIsLoading(true);
-
-        const response = await getMember();
-
-        setMemberInfo(response);
-      } catch (error) {
-        alert(error || "회원 정보를 불러올 수 없습니다.");
-
-        router.replace("/group");
-      } finally {
-        setIsLoading(false);
       }
     }, 100);
 
     // cleanup: 다음 effect 실행 전에 이전 timeout 취소
     return () => {
       clearTimeout(timeoutId);
-      clearTimeout(timeoutId2);
     };
   }, [teamId, router]);
 
@@ -165,18 +150,6 @@ export default function GroupInfoPageClient() {
       ) || []
     );
   };
-
-  if (isLoading) {
-    return (
-      <div className="flex flex-col h-screen bg-white">
-        <TopBar />
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-gray-500">로딩 중...</div>
-        </div>
-        <BottomBar />
-      </div>
-    );
-  }
 
   if (!groupInfo) {
     return (

--- a/src/components/profile/ProfilePageClient.tsx
+++ b/src/components/profile/ProfilePageClient.tsx
@@ -1,54 +1,28 @@
 // components/profile/ProfilePageClient.tsx
 "use client";
 
-import React, { useEffect, useState, useRef } from "react";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import Image from "next/image";
 import TopBar from "@/components/ui/TopBar";
 import BottomBar from "@/components/ui/BottomBar";
-import { getMember, Member } from "@/services/memberService";
+import { useMemberStore } from "@/stores/useMemberStore";
+import { useAuth } from "@/hooks/useAuth";
 
 export default function ProfilePageClient() {
-  const [member, setMember] = useState<Member | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+  const router = useRouter();
+  const { member, fetchMember } = useMemberStore();
+  const { logout, isLoggedIn } = useAuth();
 
+  // 회원 정보가 없으면 가져오기 (단, 로그인된 상태에서만)
   useEffect(() => {
-    // 기존 디바운스 타이머 제거
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
+    if (!member && isLoggedIn) {
+      fetchMember();
     }
+  }, [member, isLoggedIn, fetchMember]);
 
-    // 디바운스 적용된 API 호출
-    debounceRef.current = setTimeout(async () => {
-      try {
-        const memberData = await getMember();
-        setMember(memberData);
-        setError(null);
-      } catch (err) {
-        setError("회원 정보를 불러오는데 실패했습니다.");
-        console.error("Failed to fetch member:", err);
-
-        // 에러 발생 시 기본값 설정
-        setMember({
-          email: "",
-          name: "",
-          nickname: "사용자",
-          profileImageUrl: "",
-        });
-      }
-    }, 100);
-
-    return () => {
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
-    };
-  }, []);
-
-  // 에러 재시도 함수
-  const handleRetry = () => {
-    setError(null);
-    window.location.reload();
+  const handleProfileUpdate = () => {
+    router.push("/profile/update");
   };
 
   const handlePrivacyPolicy = () => {
@@ -65,43 +39,52 @@ export default function ProfilePageClient() {
     );
   };
 
+  const handleLogout = () => {
+    logout();
+  };
+
+  const handleWithdrawal = () => {
+    if (
+      confirm("정말로 회원탈퇴를 하시겠습니까?\n이 작업은 되돌릴 수 없습니다.")
+    ) {
+      // 회원탈퇴 로직 구현 필요
+      console.log("회원탈퇴 처리");
+    }
+  };
+
+  // 로그인 상태가 아니거나 회원 정보가 없는 경우
+  if (!member) {
+    return <div className="h-screen bg-white flex flex-col"></div>;
+  }
+
   return (
     <div className="h-screen bg-white flex flex-col">
       <TopBar />
 
-      {/* 에러 토스트 */}
-      {error && (
-        <div className="bg-red-50 border-l-4 border-red-400 p-4 mx-6 mt-4">
-          <div className="flex justify-between items-center">
-            <div className="flex">
-              <span className="text-red-700 text-sm">{error}</span>
-            </div>
-            <button
-              onClick={handleRetry}
-              className="text-red-600 text-sm underline hover:text-red-800"
-            >
-              다시 시도
-            </button>
-          </div>
-        </div>
-      )}
-
       <main className="flex-1 px-6 py-4 overflow-y-auto">
         {/* Profile Section */}
         <div className="text-center mb-6">
-          <h1 className="text-2xl text-black mb-4">{member?.nickname}</h1>
+          <h1 className="text-2xl text-black mb-4">
+            {member?.nickname || "사용자"}
+          </h1>
 
           <div className="w-24 h-24 mx-auto mb-6 relative">
-            {member?.profileImageUrl && (
+            {member?.profileImageUrl ? (
               <Image
                 src={member.profileImageUrl}
-                alt={`${member.nickname}의 프로필`}
-                width={24}
-                height={24}
+                alt={`${member.nickname || "사용자"}의 프로필`}
+                width={96}
+                height={96}
                 quality={100}
                 unoptimized={true}
                 className="w-24 h-24 rounded-full object-cover"
               />
+            ) : (
+              <div className="w-24 h-24 rounded-full bg-gray-200 flex items-center justify-center">
+                <span className="text-gray-500 text-2xl">
+                  {member?.nickname?.charAt(0) || "?"}
+                </span>
+              </div>
             )}
           </div>
         </div>
@@ -109,7 +92,10 @@ export default function ProfilePageClient() {
         {/* Menu Section */}
         <div className="bg-gray-50 rounded-lg shadow-sm">
           <div className="divide-y divide-gray-100">
-            <button className="w-full flex items-center justify-between p-4 hover:bg-gray-100 cursor-pointer transition-colors">
+            <button
+              onClick={handleProfileUpdate}
+              className="w-full flex items-center justify-between p-4 hover:bg-gray-100 cursor-pointer transition-colors"
+            >
               <span className="text-gray-600">프로필 수정</span>
               <span className="text-gray-400">›</span>
             </button>
@@ -139,10 +125,16 @@ export default function ProfilePageClient() {
 
         {/* Logout & Withdrawal Buttons */}
         <div className="mt-6 space-y-3">
-          <button className="w-full bg-red-50 text-red-600 py-3 px-4 rounded-lg text-sm font-medium hover:bg-red-100 cursor-pointer transition-colors">
+          <button
+            onClick={handleLogout}
+            className="w-full bg-red-50 text-red-600 py-3 px-4 rounded-lg text-sm font-medium hover:bg-red-100 cursor-pointer transition-colors"
+          >
             로그아웃
           </button>
-          <button className="w-full text-gray-400 py-3 px-4 rounded-lg text-sm font-medium hover:bg-gray-100 cursor-pointer transition-colors">
+          <button
+            onClick={handleWithdrawal}
+            className="w-full text-gray-400 py-3 px-4 rounded-lg text-sm font-medium hover:bg-gray-100 cursor-pointer transition-colors"
+          >
             회원탈퇴
           </button>
         </div>

--- a/src/components/profile/ProfilePageClient.tsx
+++ b/src/components/profile/ProfilePageClient.tsx
@@ -80,11 +80,7 @@ export default function ProfilePageClient() {
                 className="w-24 h-24 rounded-full object-cover"
               />
             ) : (
-              <div className="w-24 h-24 rounded-full bg-gray-200 flex items-center justify-center">
-                <span className="text-gray-500 text-2xl">
-                  {member?.nickname?.charAt(0) || "?"}
-                </span>
-              </div>
+              <div className="w-24 h-24 rounded-full bg-gray-200 flex items-center justify-center"></div>
             )}
           </div>
         </div>

--- a/src/components/profile/ProfilePageClient.tsx
+++ b/src/components/profile/ProfilePageClient.tsx
@@ -72,7 +72,7 @@ export default function ProfilePageClient() {
             {member?.profileImageUrl ? (
               <Image
                 src={member.profileImageUrl}
-                alt={`${member.nickname || "사용자"}의 프로필`}
+                alt={`${member.nickname}`}
                 width={96}
                 height={96}
                 quality={100}

--- a/src/components/profile/ProfilePageClient.tsx
+++ b/src/components/profile/ProfilePageClient.tsx
@@ -1,0 +1,154 @@
+// components/profile/ProfilePageClient.tsx
+"use client";
+
+import React, { useEffect, useState, useRef } from "react";
+import Image from "next/image";
+import TopBar from "@/components/ui/TopBar";
+import BottomBar from "@/components/ui/BottomBar";
+import { getMember, Member } from "@/services/memberService";
+
+export default function ProfilePageClient() {
+  const [member, setMember] = useState<Member | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    // 기존 디바운스 타이머 제거
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    // 디바운스 적용된 API 호출
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const memberData = await getMember();
+        setMember(memberData);
+        setError(null);
+      } catch (err) {
+        setError("회원 정보를 불러오는데 실패했습니다.");
+        console.error("Failed to fetch member:", err);
+
+        // 에러 발생 시 기본값 설정
+        setMember({
+          email: "",
+          name: "",
+          nickname: "사용자",
+          profileImageUrl: "",
+        });
+      }
+    }, 100);
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
+
+  // 에러 재시도 함수
+  const handleRetry = () => {
+    setError(null);
+    window.location.reload();
+  };
+
+  const handlePrivacyPolicy = () => {
+    window.open(
+      "https://dalcoomi.notion.site/2326ea725ec881628880db9f9f487680",
+      "_blank"
+    );
+  };
+
+  const handleTermsOfService = () => {
+    window.open(
+      "https://dalcoomi.notion.site/2326ea725ec880d69db1ecccb049bcf9",
+      "_blank"
+    );
+  };
+
+  return (
+    <div className="h-screen bg-white flex flex-col">
+      <TopBar />
+
+      {/* 에러 토스트 */}
+      {error && (
+        <div className="bg-red-50 border-l-4 border-red-400 p-4 mx-6 mt-4">
+          <div className="flex justify-between items-center">
+            <div className="flex">
+              <span className="text-red-700 text-sm">{error}</span>
+            </div>
+            <button
+              onClick={handleRetry}
+              className="text-red-600 text-sm underline hover:text-red-800"
+            >
+              다시 시도
+            </button>
+          </div>
+        </div>
+      )}
+
+      <main className="flex-1 px-6 py-4 overflow-y-auto">
+        {/* Profile Section */}
+        <div className="text-center mb-6">
+          <h1 className="text-2xl text-black mb-4">{member?.nickname}</h1>
+
+          <div className="w-24 h-24 mx-auto mb-6 relative">
+            {member?.profileImageUrl && (
+              <Image
+                src={member.profileImageUrl}
+                alt={`${member.nickname}의 프로필`}
+                width={24}
+                height={24}
+                quality={100}
+                unoptimized={true}
+                className="w-24 h-24 rounded-full object-cover"
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Menu Section */}
+        <div className="bg-gray-50 rounded-lg shadow-sm">
+          <div className="divide-y divide-gray-100">
+            <button className="w-full flex items-center justify-between p-4 hover:bg-gray-100 cursor-pointer transition-colors">
+              <span className="text-gray-600">프로필 수정</span>
+              <span className="text-gray-400">›</span>
+            </button>
+          </div>
+        </div>
+
+        {/* Policy & Help Section */}
+        <div className="bg-gray-50 rounded-lg text-sm shadow-sm mt-4">
+          <div className="divide-y divide-gray-100">
+            <button
+              onClick={handlePrivacyPolicy}
+              className="w-full flex items-center justify-between p-4 hover:bg-gray-100 cursor-pointer transition-colors"
+            >
+              <span className="text-gray-600">개인정보 처리방침</span>
+              <span className="text-gray-400">›</span>
+            </button>
+
+            <button
+              onClick={handleTermsOfService}
+              className="w-full flex items-center justify-between p-4 hover:bg-gray-100 cursor-pointer transition-colors"
+            >
+              <span className="text-gray-600">서비스 이용약관</span>
+              <span className="text-gray-400">›</span>
+            </button>
+          </div>
+        </div>
+
+        {/* Logout & Withdrawal Buttons */}
+        <div className="mt-6 space-y-3">
+          <button className="w-full bg-red-50 text-red-600 py-3 px-4 rounded-lg text-sm font-medium hover:bg-red-100 cursor-pointer transition-colors">
+            로그아웃
+          </button>
+          <button className="w-full text-gray-400 py-3 px-4 rounded-lg text-sm font-medium hover:bg-gray-100 cursor-pointer transition-colors">
+            회원탈퇴
+          </button>
+        </div>
+      </main>
+
+      <BottomBar />
+    </div>
+  );
+}

--- a/src/components/profile/ProfileUpdatePageClient.tsx
+++ b/src/components/profile/ProfileUpdatePageClient.tsx
@@ -1,0 +1,570 @@
+// components/profile/ProfileUpdatePageClient.tsx
+"use client";
+
+import React, { useState, useRef, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import TopBar from "@/components/ui/TopBar";
+import BottomBar from "@/components/ui/BottomBar";
+import {
+  updateProfile,
+  updateAvatar,
+  checkNicknameAvailability,
+  SocialType,
+} from "@/services/memberService";
+import { useMemberStore } from "@/stores/useMemberStore";
+import { validateNickname, validateName } from "@/utils/validation";
+
+export default function ProfileUpdatePageClient() {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Zustand 스토어에서 상태와 액션 가져오기
+  const { member, fetchMember, updateMember } = useMemberStore();
+
+  // 수정할 정보 상태 (로컬에서 관리)
+  const [profileImage, setProfileImage] = useState<string>("");
+  const [nickname, setNickname] = useState<string>("");
+  const [name, setName] = useState<string>("");
+  const [birthday, setBirthday] = useState<string>("");
+  const [gender, setGender] = useState<string>("");
+  const [nicknameCheckResult, setNicknameCheckResult] = useState<
+    "none" | "available" | "unavailable"
+  >("none");
+  const [nicknameError, setNicknameError] = useState<string>("");
+  const [nameError, setNameError] = useState<string>("");
+
+  // UI 상태
+  const [showAvatarModal, setShowAvatarModal] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // 기본 프로필 사진 URL들
+  const defaultAvatars = [
+    process.env.NEXT_PUBLIC_DEFAULT_AVATAR_1,
+    process.env.NEXT_PUBLIC_DEFAULT_AVATAR_2,
+    process.env.NEXT_PUBLIC_DEFAULT_AVATAR_3,
+    process.env.NEXT_PUBLIC_DEFAULT_AVATAR_4,
+  ].filter(Boolean);
+
+  // 현재 프로필 사진이 기본 사진인지 확인
+  const isDefaultAvatar = profileImage && defaultAvatars.includes(profileImage);
+
+  // 초기 데이터 로드 (Zustand 스토어를 통해 처리)
+  useEffect(() => {
+    // 페이지 로드 시 회원 정보가 없으면 fetchMember 호출
+    if (!member) {
+      fetchMember();
+    }
+  }, [member, fetchMember]);
+
+  // Zustand 스토어의 member가 업데이트되면 로컬 상태 업데이트
+  useEffect(() => {
+    if (member) {
+      setProfileImage(member.profileImageUrl || "");
+      setNickname(member.nickname || "");
+      setName(member.name || "");
+      setBirthday(member.birthday || "");
+      setGender(member.gender || "");
+    }
+  }, [member]);
+
+  // 프로필 사진 변경
+  const handleImageClick = () => {
+    setShowAvatarModal(true);
+  };
+
+  // 프로필 사진 수정 선택
+  const handleEditAvatar = () => {
+    setShowAvatarModal(false);
+    fileInputRef.current?.click();
+  };
+
+  // 프로필 사진 수정
+  const handleImageChange = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    // 이미지 파일 검증
+    if (!file.type.startsWith("image/")) {
+      alert(err.message || "이미지 파일만 업로드 가능합니다.");
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+      return;
+    }
+
+    // 파일 크기 검증 (10MB)
+    if (file.size > 10 * 1024 * 1024) {
+      alert(err.message || "파일 크기는 10MB 이하여야 합니다.");
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+      return;
+    }
+
+    // 이미 제출 중이면 무시
+    if (isSubmitting) {
+      return;
+    }
+
+    // 제출 시작
+    setIsSubmitting(true);
+
+    try {
+      const newAvatarUrl = await updateAvatar(file, false);
+
+      // Zustand 스토어 업데이트
+      updateMember({ profileImageUrl: newAvatarUrl });
+
+      setProfileImage(newAvatarUrl);
+    } catch (err) {
+      console.error("Profile image update failed:", err);
+      alert(err.message || "프로필 사진 변경에 실패했습니다.");
+    } finally {
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+      setIsSubmitting(false);
+    }
+  };
+
+  // 프로필 사진 기본 이미지로 변경
+  const handleChangeDefaultAvatar = async () => {
+    setShowAvatarModal(false);
+
+    try {
+      const newAvatarUrl = await updateAvatar(null, true);
+
+      // Zustand 스토어 업데이트
+      updateMember({ profileImageUrl: newAvatarUrl });
+
+      setProfileImage(newAvatarUrl);
+    } catch (err) {
+      console.error("Profile image change failed:", err);
+      alert(err.message || "프로필 사진 변경에 실패했습니다.");
+    }
+  };
+
+  // 닉네임 중복 확인 핸들러
+  const handleCheckNickname = async () => {
+    // 현재 닉네임과 같으면 확인할 필요 없음
+    if (member?.nickname === nickname.trim()) {
+      setNicknameCheckResult("available");
+      setNicknameError("");
+      return;
+    } else {
+      const nicknameValidationError = validateNickname(nickname);
+      if (nicknameValidationError) {
+        setNicknameError(nicknameValidationError);
+        return;
+      }
+    }
+
+    try {
+      const isAvailable = await checkNicknameAvailability(nickname.trim());
+      setNicknameCheckResult(isAvailable ? "available" : "unavailable");
+      setNicknameError("");
+    } catch (error) {
+      console.error("Nickname check failed:", error);
+      alert(error.message || "닉네임 확인에 실패했습니다.");
+      setNicknameCheckResult("none");
+    }
+  };
+
+  // 닉네임 변경 핸들러
+  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newNickname = e.target.value;
+    setNickname(newNickname);
+    setNicknameCheckResult("none");
+
+    // 실시간 검증
+    if (member?.nickname === newNickname.trim()) {
+      setNicknameError("");
+      return;
+    } else {
+      const error = validateNickname(newNickname);
+      setNicknameError(error || "");
+    }
+  };
+
+  // 이름 변경 핸들러
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newName = e.target.value;
+    setName(newName);
+
+    // 실시간 검증
+    const error = validateName(newName);
+    setNameError(error || "");
+  };
+
+  // 회원 정보 수정
+  const handleUpdateProfile = async () => {
+    // 현재 닉네임과 같으면 확인할 필요 없음
+    if (member?.nickname === nickname.trim()) {
+      setNicknameError("");
+    } else {
+      const nicknameValidationError = validateNickname(nickname);
+      if (nicknameValidationError) {
+        setNicknameError(nicknameValidationError);
+        return;
+      }
+    }
+
+    const nameValidationError = validateName(name);
+    if (nameValidationError) {
+      setNameError(nameValidationError);
+      return;
+    }
+
+    // 버튼이 비활성화되어 있으면 실행되지 않아야 함
+    if (isUpdateButtonDisabled()) {
+      return;
+    }
+
+    // 제출 시작
+    setIsSubmitting(true);
+
+    try {
+      const updateData = {
+        nickname: nickname.trim(),
+        name: name.trim(),
+        birthday: birthday || undefined,
+        gender: gender || undefined,
+      };
+
+      const updatedProfile = await updateProfile(updateData);
+
+      // Zustand 스토어 업데이트
+      updateMember({
+        nickname: updatedProfile.nickname,
+        name: updatedProfile.name,
+        birthday: updatedProfile.birthday,
+        gender: updatedProfile.gender,
+      });
+
+      router.back();
+    } catch (err) {
+      console.error("Profile update failed:", err);
+      alert(err.message || "프로필 수정에 실패했습니다. ");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // 수정 완료 버튼 활성화 조건 계산
+  const isUpdateButtonDisabled = () => {
+    // 기본 검증 실패
+    if (nicknameError || nameError) return true;
+
+    // 필수 필드 비어있음
+    if (!nickname.trim() || !name.trim()) return true;
+
+    // 제출 중
+    if (isSubmitting) return true;
+
+    // 닉네임이 변경되었는데 중복 확인 안함
+    if (
+      member?.nickname !== nickname.trim() &&
+      nicknameCheckResult !== "available"
+    ) {
+      return true;
+    }
+
+    return false;
+  };
+
+  // 소셜 타입 변환 함수
+  const getSocialDisplayName = (socialType: SocialType) => {
+    switch (socialType) {
+      case SocialType.KAKAO:
+        return "카카오";
+      case SocialType.NAVER:
+        return "네이버";
+      default:
+        return socialType;
+    }
+  };
+
+  // 소셜 타입별 스타일 클래스
+  const getSocialStyleClass = (socialType: SocialType) => {
+    switch (socialType) {
+      case SocialType.KAKAO:
+        return "bg-[#fae100] text-[#3f211e]";
+      case SocialType.NAVER:
+        return "bg-green-500 text-white";
+      default:
+        return "bg-gray-100 text-gray-600";
+    }
+  };
+
+  if (!member) {
+    return <div className="h-screen bg-white flex flex-col"></div>;
+  }
+
+  return (
+    <div className="h-screen bg-white flex flex-col">
+      <TopBar />
+
+      <div className="bg-[#11ABFF] text-white px-4 py-2 flex items-center">
+        <h1 className="text-xl font-light">프로필 수정</h1>
+      </div>
+
+      <main className="flex-1 px-6 py-5 overflow-y-auto">
+        {/* 프로필 사진 섹션 */}
+        <div className="text-center mb-5">
+          <div className="relative w-24 h-24 mx-auto mb-4">
+            {profileImage ? (
+              <Image
+                src={profileImage}
+                alt="프로필 사진"
+                width={96}
+                height={96}
+                quality={100}
+                unoptimized={true}
+                className="w-24 h-24 rounded-full object-cover cursor-pointer"
+                onClick={handleImageClick}
+              />
+            ) : (
+              <div
+                className="w-24 h-24 bg-white rounded-full flex items-center justify-center cursor-pointer"
+                onClick={handleImageClick}
+              ></div>
+            )}
+          </div>
+
+          <button
+            onClick={handleImageClick}
+            className="text-sm text-blue-500 hover:text-blue-700 cursor-pointer"
+          >
+            프로필 사진 변경
+          </button>
+
+          {/* 프로필 사진 수정/기본 이미지로 변경 모달 */}
+          {showAvatarModal && (
+            <>
+              {/* 배경 오버레이 */}
+              <div
+                className="absolute top-0 left-0 right-0 bottom-0 bg-[#d9d9d9] opacity-50 flex h-screen items-center justify-center z-50"
+                onClick={() => setShowAvatarModal(false)}
+              ></div>
+
+              {/* 모달 컨텐츠 */}
+              <div
+                className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white border-2 border-[#C7C3C3] rounded-[10px] p-2 w-[80%] z-50"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {/* 버튼들 */}
+                <div className="flex">
+                  <button
+                    onClick={handleEditAvatar}
+                    className="flex-1 mx-10 mb-4 mt-2 py-2 text-[#0EABFF] font-light border-3 rounded-[10px] hover:bg-blue-100 cursor-pointer transition-colors"
+                  >
+                    사진 선택
+                  </button>
+                </div>
+
+                {/* 기본 프사가 아닐 때만 기본 이미지로 변경 버튼 표시 */}
+                {profileImage && !isDefaultAvatar && (
+                  <div className="flex">
+                    <button
+                      onClick={handleChangeDefaultAvatar}
+                      className="flex-1 mx-10 mb-4 py-2 text-gray-600 font-light border-3 rounded-[10px] hover:bg-gray-200 cursor-pointer transition-colors"
+                    >
+                      기본 이미지로 변경
+                    </button>
+                  </div>
+                )}
+
+                <div className="flex">
+                  <button
+                    onClick={() => setShowAvatarModal(false)}
+                    className="flex-1 mx-10 mb-2 py-2 text-gray-600 font-light border-3 rounded-[10px] hover:bg-gray-200 cursor-pointer transition-colors"
+                  >
+                    취소
+                  </button>
+                </div>
+              </div>
+            </>
+          )}
+
+          {/* 숨겨진 파일 입력 */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={handleImageChange}
+            className="hidden"
+          />
+        </div>
+
+        {/* 폼 섹션 */}
+        <div className="space-y-3">
+          {/* 닉네임 */}
+          <div>
+            <label className="block text-sm text-gray-700 mb-1">
+              닉네임 <span className="text-red-500">*</span>
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={nickname}
+                onChange={handleNicknameChange}
+                className="flex-1 p-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
+                placeholder="닉네임을 입력하세요"
+                maxLength={15}
+              />
+              <button
+                type="button"
+                onClick={handleCheckNickname}
+                className="px-4 py-2 bg-gray-100 text-gray-600 rounded-lg border border-gray-300 hover:bg-gray-200 transition-colors cursor-pointer text-sm whitespace-nowrap"
+              >
+                중복 확인
+              </button>
+            </div>
+
+            {/* 에러 메시지 */}
+            {nicknameError && (
+              <p className="text-xs text-red-500 mt-1 ml-1">{nicknameError}</p>
+            )}
+
+            {/* 확인 결과 메시지 */}
+            {nicknameCheckResult === "available" && (
+              <p className="text-xs text-green-500 mt-1 ml-1">
+                사용 가능한 닉네임입니다.
+              </p>
+            )}
+
+            {nicknameCheckResult === "unavailable" && (
+              <p className="text-xs text-red-500 mt-1 ml-1">
+                이미 사용 중인 닉네임입니다.
+              </p>
+            )}
+          </div>
+
+          {/* 이름 */}
+          <div>
+            <label className="block text-sm text-gray-700 mb-1">
+              이름 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={handleNameChange}
+              className="w-full p-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
+              placeholder="이름을 입력하세요"
+              maxLength={30}
+            />
+
+            {nameError && (
+              <p className="text-xs text-red-500 mt-1 ml-1">{nameError}</p>
+            )}
+          </div>
+
+          {/* 생년월일 */}
+          <div>
+            <label className="block text-sm text-gray-700 mb-1">생년월일</label>
+            <input
+              type="date"
+              value={birthday}
+              onChange={(e) => setBirthday(e.target.value)}
+              className="w-full p-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
+            />
+          </div>
+
+          {/* 성별 */}
+          <div>
+            <label className="block text-sm text-gray-700 mb-1">성별</label>
+            <div className="flex space-x-4">
+              <button
+                type="button"
+                onClick={() => setGender(gender === "남성" ? "" : "남성")}
+                className={`flex-1 py-2 border-2 rounded-[10px] transition-colors cursor-pointer ${
+                  gender === "남성"
+                    ? "border-[#2FA5FF] text-[#2FA5FF] bg-[#DDECFF]"
+                    : "border-[#808080] bg-white text-[#808080]"
+                }`}
+              >
+                남
+              </button>
+              <button
+                type="button"
+                onClick={() => setGender(gender === "여성" ? "" : "여성")}
+                className={`flex-1 py-2 border-2 rounded-[10px] transition-colors cursor-pointer ${
+                  gender === "여성"
+                    ? "border-[#2FA5FF] text-[#2FA5FF] bg-[#DDECFF]"
+                    : "border-[#808080] bg-white text-[#808080]"
+                }`}
+              >
+                여
+              </button>
+            </div>
+          </div>
+
+          {/* 연결된 계정 */}
+          <div>
+            <label className="block text-sm text-gray-700 mb-2">
+              연결된 계정
+            </label>
+            <div className="p-2 bg-gray-100 rounded-lg">
+              <div className="flex items-center gap-2">
+                <span
+                  className={`text-xs px-2 py-1 rounded ${getSocialStyleClass(
+                    member.socialType
+                  )}`}
+                >
+                  {getSocialDisplayName(member.socialType)}
+                </span>
+                <p className="text-gray-600">{member.email}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* 수정 완료 버튼 */}
+        <div className="px-10 mt-8 mb-6">
+          <button
+            onClick={handleUpdateProfile}
+            disabled={isUpdateButtonDisabled()}
+            className={`w-full py-3 rounded-md font-medium transition-colors ${
+              isUpdateButtonDisabled()
+                ? "bg-[#0EABFF] opacity-50 cursor-not-allowed text-white"
+                : "bg-[#0EABFF] hover:bg-blue-500 cursor-pointer text-white"
+            }`}
+          >
+            {isSubmitting ? (
+              <span className="flex items-center justify-center cursor-not-allowed">
+                <svg
+                  className="animate-spin h-5 w-5 mr-2"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  ></circle>
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  ></path>
+                </svg>
+                처리 중...
+              </span>
+            ) : (
+              "수정 완료"
+            )}
+          </button>
+        </div>
+      </main>
+
+      <BottomBar />
+    </div>
+  );
+}

--- a/src/components/transaction/group/UpdateGroupTransactionPageClient.tsx
+++ b/src/components/transaction/group/UpdateGroupTransactionPageClient.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/services/transactionService";
 import { Transaction } from "@/services/transactionService";
 import { getTeamCategories, Category } from "@/services/categoryService";
-import { getMember, Member } from "@/services/memberService";
+import { useMemberStore } from "@/stores/useMemberStore";
 import { getGroupInfo, GroupInfo } from "@/services/groupService";
 import Image from "next/image";
 import TopBar from "@/components/ui/TopBar";
@@ -33,11 +33,10 @@ export default function UpdateGroupTransactionPageClient() {
   const router = useRouter();
   const params = useParams();
   const searchParams = useSearchParams();
+  const { member: currentUser, fetchMember } = useMemberStore();
 
   const teamId = params.teamId as string;
   const transactionId = searchParams.get("id");
-
-  const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isFormValid, setIsFormValid] = useState(false);
   const [transactionType, setTransactionType] = useState<"EXPENSE" | "INCOME">(
@@ -50,7 +49,6 @@ export default function UpdateGroupTransactionPageClient() {
   const [showCategoryModal, setShowCategoryModal] = useState<boolean>(false);
   const [amountError, setAmountError] = useState(false);
   const [amountTouched, setAmountTouched] = useState(false);
-  const [currentUser, setCurrentUser] = useState<Member | null>(null);
   const [groupInfo, setGroupInfo] = useState<GroupInfo | null>(null);
 
   // 카테고리 관련 상태
@@ -58,6 +56,13 @@ export default function UpdateGroupTransactionPageClient() {
   const [isLoadingCategories, setIsLoadingCategories] = useState(false);
   const [originalTransaction, setOriginalTransaction] =
     useState<Transaction | null>(null);
+
+  // 회원 정보가 없으면 가져오기
+  useEffect(() => {
+    if (!currentUser) {
+      fetchMember();
+    }
+  }, [currentUser, fetchMember]);
 
   // 기존 거래 내역 로드
   useEffect(() => {
@@ -74,8 +79,6 @@ export default function UpdateGroupTransactionPageClient() {
       }
 
       try {
-        setIsLoading(true);
-
         const transaction = await getTransactionById(transactionId, teamId);
 
         // 원본 거래 데이터 저장
@@ -103,8 +106,6 @@ export default function UpdateGroupTransactionPageClient() {
         alert(error || "거래 내역을 불러올 수 없습니다.");
 
         router.replace(`/transaction/group/${teamId}`);
-      } finally {
-        setIsLoading(false);
       }
     };
 
@@ -123,20 +124,9 @@ export default function UpdateGroupTransactionPageClient() {
       loadTransaction();
     }, 100);
 
-    const timeoutId3 = setTimeout(async () => {
-      try {
-        const userInfo = await getMember();
-        setCurrentUser(userInfo);
-      } catch (error) {
-        alert(error || "사용자 정보를 불러올 수 없습니다.");
-        router.replace(`/transaction/group/${teamId}`);
-      }
-    }, 100);
-
     return () => {
       clearTimeout(timeoutId1);
       clearTimeout(timeoutId2);
-      clearTimeout(timeoutId3);
     };
   }, [transactionId, router, teamId]);
 
@@ -276,18 +266,6 @@ export default function UpdateGroupTransactionPageClient() {
   // 현재 사용자가 작성자인지 확인
   const isOwner =
     currentUser?.nickname === originalTransaction?.creatorNickname;
-
-  if (isLoading) {
-    return (
-      <div className="flex flex-col h-screen bg-white">
-        <TopBar />
-        <div className="flex items-center justify-center flex-1">
-          <div className="text-gray-500">로딩 중...</div>
-        </div>
-        <BottomBar />
-      </div>
-    );
-  }
 
   return (
     <div className="flex flex-col h-screen bg-white">

--- a/src/components/transaction/my/MyTransactionPageClient.tsx
+++ b/src/components/transaction/my/MyTransactionPageClient.tsx
@@ -16,7 +16,7 @@ import {
 export default function MyTransactionPageClient() {
   const router = useRouter();
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isLoading, setIsLoading] = useState<boolean>(false); // 초기 로딩 제거
   const [response, setResponse] = useState<MonthlyTransactionsResponse>({
     income: 0,
     expense: 0,
@@ -43,19 +43,15 @@ export default function MyTransactionPageClient() {
   // 필터 드롭다운 외부 클릭 감지를 위한 ref
   const categoryDropdownRef = useRef<HTMLDivElement>(null);
 
-  // 날짜 변경 핸들러 (필터 유지)
-  const handleDateChange = (date: Date) => {
-    setSelectedDate(date);
-    // 필터는 유지하고, 드롭다운만 닫기
-    setShowCategoryFilter(false);
-  };
+  // 통합된 useEffect로 중복 호출 방지
+  useEffect(() => {
+    const year = selectedDate.getFullYear();
+    const month = selectedDate.getMonth() + 1;
 
-  // 트랜잭션 데이터 로드
-  const loadTransactions = useCallback(
-    async (year: number, month: number, categoryFilter?: string | null) => {
-      const requestKey = `${year}-${month}-${categoryFilter || ""}`;
+    const timeoutId = setTimeout(() => {
+      // loadTransactions 직접 호출하지 않고 내부 로직 실행
+      const requestKey = `${year}-${month}-${currentCategoryFilter || ""}`;
 
-      // 같은 요청이 진행 중이면 무시
       if (
         isRequestInProgressRef.current &&
         lastRequestRef.current === requestKey
@@ -63,75 +59,60 @@ export default function MyTransactionPageClient() {
         return;
       }
 
-      // 요청 시작
       isRequestInProgressRef.current = true;
       lastRequestRef.current = requestKey;
       setIsLoading(true);
 
-      try {
-        const criteria: TransactionSearchCriteria = {
-          teamId: null, // 개인 거래
-          year,
-          month,
-          categoryName: categoryFilter,
-        };
-
-        const response = await getTransactions(criteria);
-        setResponse(response);
-
-        // 필터가 없는 경우에만 전체 카테고리 목록 갱신
-        if (!categoryFilter) {
-          // 전체 데이터를 다시 조회해서 카테고리 목록 추출
-          const allDataCriteria: TransactionSearchCriteria = {
+      const fetchData = async () => {
+        try {
+          const criteria: TransactionSearchCriteria = {
             teamId: null,
             year,
             month,
-            categoryName: null,
+            categoryName: currentCategoryFilter,
           };
 
-          const allDataResponse = await getTransactions(allDataCriteria);
-          const uniqueCategories = Array.from(
-            new Set(allDataResponse.transactions.map((t) => t.categoryName))
-          );
-          setAllCategories(uniqueCategories);
+          const response = await getTransactions(criteria);
+          setResponse(response);
+
+          if (!currentCategoryFilter && allCategories.length === 0) {
+            const uniqueCategories = Array.from(
+              new Set(response.transactions.map((t) => t.categoryName))
+            );
+            setAllCategories(uniqueCategories);
+          }
+        } catch (error) {
+          if (error instanceof Error && error.message.includes("401")) {
+            window.location.href = "/";
+            return;
+          }
+
+          setResponse({
+            income: 0,
+            expense: 0,
+            total: 0,
+            transactions: [],
+          });
+        } finally {
+          setIsLoading(false);
+          isRequestInProgressRef.current = false;
         }
-      } catch (error) {
-        // 401 에러면 루트(로그인)로 리다이렉트
-        if (error instanceof Error && error.message.includes("401")) {
-          router.replace("/");
-          return;
-        }
+      };
 
-        // 기타 오류 처리
-        setResponse({
-          income: 0,
-          expense: 0,
-          total: 0,
-          transactions: [],
-        });
-      } finally {
-        setIsLoading(false);
-        isRequestInProgressRef.current = false;
-      }
-    },
-    [router]
-  );
-
-  // 초기 데이터 로드 및 날짜 변경 시 (현재 필터 유지)
-  useEffect(() => {
-    const year = selectedDate.getFullYear();
-    const month = selectedDate.getMonth() + 1;
-
-    // 약간의 디바운스 추가
-    const timeoutId = setTimeout(() => {
-      // 현재 선택된 필터를 유지하여 로드
-      loadTransactions(year, month, currentCategoryFilter);
-    }, 100);
+      fetchData();
+    }, 300);
 
     return () => {
       clearTimeout(timeoutId);
     };
-  }, [loadTransactions, selectedDate, currentCategoryFilter]);
+  }, [selectedDate, currentCategoryFilter, allCategories.length]); // loadTransactions 의존성 완전 제거
+
+  // 날짜 변경 핸들러 (필터 유지)
+  const handleDateChange = (date: Date) => {
+    setSelectedDate(date);
+    // 필터는 유지하고, 드롭다운만 닫기
+    setShowCategoryFilter(false);
+  };
 
   // 외부 클릭 감지
   useEffect(() => {
@@ -171,12 +152,8 @@ export default function MyTransactionPageClient() {
     setSelectedCategories(newSelection);
 
     // 바로 필터링 적용
-    const year = selectedDate.getFullYear();
-    const month = selectedDate.getMonth() + 1;
     const categoryFilter = newSelection.length > 0 ? newSelection[0] : null;
-
     setCurrentCategoryFilter(categoryFilter);
-    loadTransactions(year, month, categoryFilter);
 
     // 드롭다운 닫기
     setShowCategoryFilter(false);
@@ -187,11 +164,6 @@ export default function MyTransactionPageClient() {
     setSelectedCategories([]);
     setCurrentCategoryFilter(null);
 
-    // 바로 필터링 적용
-    const year = selectedDate.getFullYear();
-    const month = selectedDate.getMonth() + 1;
-    loadTransactions(year, month, null);
-
     // 드롭다운 닫기
     setShowCategoryFilter(false);
   };
@@ -200,10 +172,6 @@ export default function MyTransactionPageClient() {
   const handleResetFilters = () => {
     setSelectedCategories([]);
     setCurrentCategoryFilter(null);
-
-    const year = selectedDate.getFullYear();
-    const month = selectedDate.getMonth() + 1;
-    loadTransactions(year, month, null);
   };
 
   // 날짜를 "MM.DD" 형식으로 변환
@@ -271,12 +239,6 @@ export default function MyTransactionPageClient() {
   return (
     <div className="flex flex-col h-screen bg-white">
       <TopBar />
-
-      {/* 거래 내역 작성 제목 블록 */}
-      {/* <div className="text-[#11ABFF] px-4 py-2 items-center">
-        <h1 className="text-xl font-light text-center">
-          {memberInfo?.nickname}의 가계부
-        </h1> */}
 
       {/* 파란색 박스 영역 */}
       <div className="px-2 py-2">

--- a/src/components/ui/TopBar.tsx
+++ b/src/components/ui/TopBar.tsx
@@ -3,7 +3,7 @@
 
 import { useRouter, usePathname } from "next/navigation";
 import Image from "next/image";
-import { useCallback } from "react";
+import { useCallback, useState, useRef, useEffect } from "react";
 
 interface TopBarProps {
   showBackButton?: boolean;
@@ -19,6 +19,8 @@ export default function TopBar({
 }: TopBarProps) {
   const router = useRouter();
   const pathname = usePathname();
+  const [showSidebar, setShowSidebar] = useState(false);
+  const sidebarRef = useRef<HTMLDivElement>(null);
 
   const handleBackClick = () => {
     if (onBackClick) {
@@ -37,10 +39,6 @@ export default function TopBar({
 
     // 현재 페이지가 /transaction/my 인 경우
     if (pathname === "/transaction/my") {
-      // 방법 1: 페이지 완전 새로고침
-      // window.location.reload();
-
-      // 방법 2: 페이지 리로드 (동일한 URL로 이동)
       window.location.href = "/transaction/my";
     } else {
       // 다른 페이지에서는 일반적인 라우팅
@@ -48,72 +46,157 @@ export default function TopBar({
     }
   }, [pathname, router, onLogoClick]);
 
+  // 햄버거 메뉴 클릭 핸들러
+  const handleMenuClick = () => {
+    setShowSidebar(true);
+  };
+
+  // 외부 클릭 감지
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        sidebarRef.current &&
+        !sidebarRef.current.contains(event.target as Node)
+      ) {
+        setShowSidebar(false);
+      }
+    };
+
+    if (showSidebar) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [showSidebar]);
+
+  // 메뉴 항목 클릭 핸들러들
+  const handleMyPage = () => {
+    router.push("/profile");
+    setShowSidebar(false);
+  };
+
+  const handleNotice = () => {
+    alert("서비스 준비 중입니다.");
+  };
+
+  const handleContactUs = () => {
+    alert("서비스 준비 중입니다.");
+  };
+
   return (
-    <div className="bg-[#11ABFF] text-white h-11 flex items-center justify-between w-full relative">
-      {/* 왼쪽 - 뒤로가기 버튼 */}
-      <div className="flex items-left w-10">
-        {showBackButton && (
+    <>
+      <div className="bg-[#11ABFF] text-white h-11 flex items-center justify-between w-full relative">
+        {/* 왼쪽 - 뒤로가기 버튼 */}
+        <div className="flex items-left w-10">
+          {showBackButton && (
+            <button
+              onClick={handleBackClick}
+              className="flex cursor-pointer items-left justify-left"
+            >
+              <svg
+                width="40"
+                height="40"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15 18L9 12L15 6"
+                  stroke="white"
+                  strokeWidth="1"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+          )}
+        </div>
+
+        {/* 중앙 - 로고 */}
+        <div className="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2">
+          <div
+            className="flex cursor-pointer items-center"
+            onClick={handleLogoClick}
+          >
+            <Image
+              src="/images/메인로고.svg"
+              alt="Dalcoomi"
+              width={120}
+              height={140}
+              priority
+            />
+          </div>
+        </div>
+
+        {/* 오른쪽 - 햄버거 메뉴 */}
+        <div className="flex items-center">
           <button
-            onClick={handleBackClick}
-            className="flex cursor-pointer items-left justify-left"
+            onClick={handleMenuClick}
+            className="flex cursor-pointer items-center justify-center"
           >
             <svg
-              width="40"
-              height="40"
+              width="50"
+              height="24"
               viewBox="0 0 24 24"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M15 18L9 12L15 6"
+                d="M3 12H21M3 6H21M3 18H21"
                 stroke="white"
-                strokeWidth="1"
+                strokeWidth="2"
                 strokeLinecap="round"
-                strokeLinejoin="round"
               />
             </svg>
           </button>
-        )}
-      </div>
-
-      {/* 중앙 - 로고 */}
-      <div className="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2">
-        <div
-          className="flex cursor-pointer items-center"
-          onClick={handleLogoClick}
-        >
-          <Image
-            src="/images/메인로고.svg"
-            alt="Dalcoomi"
-            width={120}
-            height={140}
-            priority
-          />
         </div>
       </div>
 
-      {/* 오른쪽 - 햄버거 메뉴 */}
-      <div className="flex items-center">
-        <button
-          onClick={() => alert("서비스 준비 중입니다.")}
-          className="flex cursor-pointer items-center justify-center"
-        >
-          <svg
-            width="50"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
+      {/* 사이드바 - TopBar와 분리하되 앱 크기 내에서만 */}
+      {showSidebar && (
+        <>
+          {/* 반투명 오버레이 - 앱 영역 내에서만 */}
+          <div
+            className="absolute inset-0 bg-[#d9d9d9] opacity-50 z-40"
+            onClick={() => setShowSidebar(false)}
+          ></div>
+
+          {/* 사이드바 */}
+          <div
+            ref={sidebarRef}
+            className="absolute top-0 right-0 h-full w-48 bg-white shadow-lg border-2 border-[#C7C3C3] transform transition-transform duration-300 ease-in-out z-50"
+            onClick={(e) => e.stopPropagation()}
           >
-            <path
-              d="M3 12H21M3 6H21M3 18H21"
-              stroke="white"
-              strokeWidth="2"
-              strokeLinecap="round"
-            />
-          </svg>
-        </button>
-      </div>
-    </div>
+            {/* 사이드바 메뉴 */}
+            <div className="pt-6 px-4">
+              <div className="space-y-2">
+                <button
+                  onClick={handleMyPage}
+                  className="w-full text-left p-3 hover:bg-gray-100 rounded-lg cursor-pointer transition-colors"
+                >
+                  <span className="text-gray-700">마이페이지</span>
+                </button>
+
+                <button
+                  onClick={handleNotice}
+                  className="w-full text-left p-3 hover:bg-gray-100 rounded-lg cursor-pointer transition-colors"
+                >
+                  <span className="text-gray-700">공지사항</span>
+                </button>
+
+                <button
+                  onClick={handleContactUs}
+                  className="w-full text-left p-3 hover:bg-gray-100 rounded-lg cursor-pointer transition-colors"
+                >
+                  <span className="text-gray-700">문의하기</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </>
   );
 }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -9,12 +9,15 @@ import {
   saveTokens,
   clearTokens,
 } from "@/utils/tokenManager";
+import { useMemberStore } from "@/stores/useMemberStore";
+import { logout as logoutAPI } from "@/services/authService";
 
 export function useAuth() {
   const router = useRouter();
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [mounted, setMounted] = useState(false);
+  const { clearMember } = useMemberStore();
 
   // 🔥 토큰 리프레시 진행 상태와 중복 방지
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
@@ -87,6 +90,7 @@ export function useAuth() {
         // 🔥 리프레시 토큰이 없으면 즉시 로그아웃 상태 설정
         if (!refreshToken) {
           clearTokens();
+          clearMember(); // 회원 정보도 제거
           setIsLoggedIn(false);
           setIsLoading(false);
           return;
@@ -108,6 +112,7 @@ export function useAuth() {
         refreshAccessToken().then((success) => {
           if (!success) {
             clearTokens();
+            clearMember(); // 회원 정보도 제거
             setIsLoggedIn(false);
 
             // 보호된 페이지에 있다면 메인으로 이동
@@ -125,12 +130,13 @@ export function useAuth() {
       } catch (error) {
         setIsLoggedIn(false);
         clearTokens();
+        clearMember(); // 회원 정보도 제거
         setIsLoading(false);
       }
     };
 
     checkAuth();
-  }, [mounted, refreshAccessToken, router]);
+  }, [mounted, refreshAccessToken, router, clearMember]);
 
   // 로그인 함수
   const login = useCallback((accessToken: string, refreshToken?: string) => {
@@ -139,20 +145,30 @@ export function useAuth() {
   }, []);
 
   // 로그아웃 함수
-  const logout = useCallback(() => {
-    clearTokens();
-    setIsLoggedIn(false);
+  const logout = useCallback(async () => {
+    try {
+      // 백엔드 로그아웃 API 호출
+      await logoutAPI();
+    } catch (error) {
+      // 로그아웃 API 실패해도 클라이언트 로그아웃은 진행
+      console.error("로그아웃 API 호출 실패:", error);
+    } finally {
+      // 클라이언트 상태 정리
+      clearTokens();
+      clearMember(); // 회원 정보도 제거
+      setIsLoggedIn(false);
 
-    const currentPath = window.location.pathname;
-    const protectedPaths = ["/transaction", "/group"];
-    const isProtectedPath = protectedPaths.some((path) =>
-      currentPath.startsWith(path)
-    );
+      const currentPath = window.location.pathname;
+      const protectedPaths = ["/transaction", "/group", "/profile"];
+      const isProtectedPath = protectedPaths.some((path) =>
+        currentPath.startsWith(path)
+      );
 
-    if (isProtectedPath) {
-      router.push("/");
+      if (isProtectedPath) {
+        router.push("/");
+      }
     }
-  }, [router]);
+  }, [router, clearMember]);
 
   // 🔥 requireAuth - 간소화 및 최적화
   const requireAuth = useCallback(
@@ -174,6 +190,7 @@ export function useAuth() {
         refreshAccessToken().then((success) => {
           if (!success) {
             clearTokens();
+            clearMember(); // 회원 정보도 제거
             setIsLoggedIn(false);
             router.replace("/");
           }
@@ -184,7 +201,7 @@ export function useAuth() {
         callback();
       }
     },
-    [isLoading, isRefreshing, router, refreshAccessToken]
+    [isLoading, isRefreshing, router, refreshAccessToken, clearMember]
   );
 
   // 🔥 requireUnauth - 리프레시 토큰 기준
@@ -224,6 +241,7 @@ export function useAuth() {
 
       setIsLoggedIn(false);
       clearTokens();
+      clearMember(); // 회원 정보도 제거
 
       const currentPath = window.location.pathname;
       const protectedPaths = ["/transaction", "/group"];
@@ -247,7 +265,7 @@ export function useAuth() {
       window.removeEventListener("auth-error", handleAuthError);
       window.removeEventListener("token-refreshed", handleTokenRefresh);
     };
-  }, [router, mounted, refreshAccessToken]);
+  }, [router, mounted, refreshAccessToken, clearMember]);
 
   // 기타 함수들
   const checkTokenValidity = useCallback(() => {
@@ -277,13 +295,14 @@ export function useAuth() {
       } else {
         setIsLoggedIn(false);
         clearTokens();
+        clearMember(); // 회원 정보도 제거
         return false;
       }
     }
 
     setIsLoggedIn(true);
     return true;
-  }, [refreshAccessToken]);
+  }, [refreshAccessToken, clearMember]);
 
   return {
     isLoggedIn,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,7 +18,7 @@ export function middleware(request: NextRequest) {
 
   const publicPaths = ["/"];
   const authOptionalPaths = ["/sign-up"];
-  const protectedPaths = ["/transaction", "/group"];
+  const protectedPaths = ["/transaction", "/group", "/profile"];
 
   const isPublicPath = publicPaths.some((p) => path === p);
   const isAuthOptionalPath = authOptionalPaths.some((p) => path.startsWith(p));

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -1,11 +1,20 @@
 // services/memberService.ts
 import { get, post, put, del } from "@/utils/apiClient";
 
+// 소셜 타입 enum 정의
+export enum SocialType {
+  KAKAO = "KAKAO",
+  NAVER = "NAVER",
+}
+
 // 멤버 타입 정의
 export interface Member {
+  socialType: SocialType;
   email: string;
   name: string;
   nickname: string;
+  birthday: string; // LocalDate는 문자열로 전송됨 (YYYY-MM-DD 형식)
+  gender: string;
   profileImageUrl: string;
 }
 

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -6,7 +6,7 @@ export interface Member {
   email: string;
   name: string;
   nickname: string;
-  profileIamgeUrl: string;
+  profileImageUrl: string;
 }
 
 // 회원 조회

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -1,5 +1,5 @@
 // services/memberService.ts
-import { get, post, put, del } from "@/utils/apiClient";
+import { get, post, put, del, patch } from "@/utils/apiClient";
 
 // 소셜 타입 enum 정의
 export enum SocialType {
@@ -18,11 +18,75 @@ export interface Member {
   profileImageUrl: string;
 }
 
+// 프로필 정보 업데이트 요청 타입
+export interface UpdateProfileRequest {
+  name: string;
+  nickname: string;
+  birthday?: string; // LocalDate 형식 (YYYY-MM-DD)
+  gender?: string;
+}
+
+// 프로필 정보 업데이트 응답 타입
+export interface UpdateProfileResponse {
+  name: string;
+  nickname: string;
+  birthday: string;
+  gender: string;
+}
+
 // 회원 조회
 export const getMember = async (): Promise<Member> => {
   try {
     const response = await get("/api/members");
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
 
+// 닉네임 사용 가능 여부 확인
+export const checkNicknameAvailability = async (
+  nickname: string
+): Promise<boolean> => {
+  try {
+    const response = await get(
+      `/api/members/nickname/availability?nickname=${encodeURIComponent(
+        nickname
+      )}`
+    );
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+// 프로필 사진 업데이트
+export const updateAvatar = async (
+  profileImage: File | null,
+  removeAvatar: boolean = false
+): Promise<string> => {
+  try {
+    const formData = new FormData();
+    formData.append("removeAvatar", removeAvatar ? "true" : "false");
+
+    if (profileImage && !removeAvatar) {
+      formData.append("profileImage", profileImage);
+    }
+
+    const response = await patch("/api/members/avatar", formData);
+
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+// 프로필 정보 업데이트
+export const updateProfile = async (
+  profileData: UpdateProfileRequest
+): Promise<UpdateProfileResponse> => {
+  try {
+    const response = await patch("/api/members/profile", profileData);
     return response;
   } catch (error) {
     throw error;

--- a/src/stores/useMemberStore.ts
+++ b/src/stores/useMemberStore.ts
@@ -1,0 +1,83 @@
+// stores/useMemberStore.ts
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { getMember } from "@/services/memberService";
+
+// 소셜 타입 enum 정의
+export enum SocialType {
+  KAKAO = "KAKAO",
+  NAVER = "NAVER",
+}
+
+// 멤버 타입 정의
+export interface Member {
+  socialType: SocialType;
+  email: string;
+  name: string;
+  nickname: string;
+  birthday: string;
+  gender: string;
+  profileImageUrl: string;
+}
+
+interface MemberStore {
+  member: Member | null;
+  isLoading: boolean;
+  error: string | null;
+
+  // Actions
+  fetchMember: () => Promise<void>;
+  setMember: (member: Member) => void;
+  clearMember: () => void;
+  updateMember: (updates: Partial<Member>) => void;
+}
+
+export const useMemberStore = create<MemberStore>()(
+  persist(
+    (set, get) => ({
+      member: null,
+      isLoading: false,
+      error: null,
+
+      fetchMember: async () => {
+        // 이미 회원 정보가 있으면 API 호출하지 않음
+        if (get().member) {
+          return;
+        }
+
+        try {
+          set({ isLoading: true, error: null });
+          const memberData = await getMember();
+          set({ member: memberData, isLoading: false });
+        } catch (error) {
+          set({
+            error:
+              error instanceof Error
+                ? error.message
+                : "회원 정보를 가져오는데 실패했습니다.",
+            isLoading: false,
+          });
+        }
+      },
+
+      setMember: (member: Member) => {
+        set({ member, error: null });
+      },
+
+      clearMember: () => {
+        set({ member: null, error: null, isLoading: false });
+      },
+
+      updateMember: (updates: Partial<Member>) => {
+        const currentMember = get().member;
+        if (currentMember) {
+          set({ member: { ...currentMember, ...updates } });
+        }
+      },
+    }),
+    {
+      name: "member-storage", // localStorage에 저장될 키 이름
+      partialize: (state) => ({ member: state.member }), // member 정보만 persist
+    }
+  )
+);

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -40,9 +40,13 @@ export const apiClient = async (
 
   // 기본 헤더 설정
   const headers: Record<string, string> = {
-    "Content-Type": "application/json",
     ...options.headers,
   };
+
+  // body가 FormData가 아닐 때만 Content-Type을 application/json으로 설정
+  if (!(options.body instanceof FormData)) {
+    headers["Content-Type"] = "application/json";
+  }
 
   // 액세스 토큰이 있으면 인증 헤더 추가
   const accessToken = getAccessToken();
@@ -226,6 +230,23 @@ export const put = (endpoint: string, data?: any, options?: RequestInit) =>
     method: "PUT",
     body: data ? JSON.stringify(data) : undefined,
   });
+
+export const patch = (endpoint: string, data?: any, options?: RequestInit) => {
+  // FormData인 경우, JSON.stringify를 하지 않고 바로 반환
+  if (data instanceof FormData) {
+    return apiClient(endpoint, {
+      ...options,
+      method: "PATCH",
+      body: data,
+    });
+  }
+
+  return apiClient(endpoint, {
+    ...options,
+    method: "PATCH",
+    body: data ? JSON.stringify(data) : undefined,
+  });
+};
 
 export const del = (endpoint: string, data?: any, options?: RequestInit) =>
   apiClient(endpoint, {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,32 @@
+// utils/validation.ts
+export const validateNickname = (nickname: string): string | null => {
+  if (!nickname || !nickname.trim()) {
+    return "닉네임은 필수입니다.";
+  }
+
+  if (nickname.length < 2 || nickname.length > 15) {
+    return "닉네임은 2~15자입니다.";
+  }
+
+  if (!/^[가-힣a-zA-Z0-9_]+$/.test(nickname)) {
+    return "닉네임은 한글, 영문, 숫자, 언더스코어만 사용 가능합니다.";
+  }
+
+  return null; // 검증 통과
+};
+
+export const validateName = (name: string): string | null => {
+  if (!name || !name.trim()) {
+    return "이름은 필수입니다.";
+  }
+
+  if (name.length < 2 || name.length > 30) {
+    return "이름은 2~30자입니다.";
+  }
+
+  if (!/^[가-힣a-zA-Z]+$/.test(name)) {
+    return "이름은 한글, 영문만 사용 가능합니다.";
+  }
+
+  return null; // 검증 통과
+};


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[#1]feat: 로그인 페이지 UI 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #57 

**✅ Tasks**

- 회원 데이터 상태 관리 로직 리팩토링
  - 기존: 회원 정보가 필요한 페이지에서 매번 회원 조회 API 호출 -> 네트워크 비용 증가 + 페이지 로딩 지연
  - 개선 후: 로그인 시 조회 API 한 번만 호출해서 데이터 프론트에 저장 후 관리
    - 회원 데이터 변경 작업 시에만 데이터 최신화
    - ``Zustand`` 상태 관리 라이브러리 추가
    - 회원 정보 사용 시 ``Zustand``의 ``store``에서 꺼내서 사용
- 마이페이지 구현
  - 닉네임, 프사 조회
  - 프로필 수정, 개인정보 처리방침, 서비스 이용약관 추가
  - 로그아웃 시 로그아웃 API 호출 + 액세스, 리프레시 토큰 삭제
- 프로필 수정 페이지 구현
  - 프로필 사진 수정과 회원 정보 수정 기능 분리
  - 프사 수정 시, 현재 프사가 서비스 기본 이미지가 아닐 경우 ``기본 이미지로 변경`` 버튼 생김. 이외엔 해당 버튼 없음.
  - 닉네임, 이름은 ``validator.ts``에서 조건 검증
- 사이드바 구현
  - 카테고리 등 기존 모달과 같은 방식
  - 마이페이지, 공지사항, 문의하기 추가
  - 공지랑 문의는 구현 안 돼서 접근 막아둠

**🙋🏻 More**
- 로그아웃 시, 소셜 연동 해제 추가할 지 고려 중
- 회원탈퇴는 다음 작업에서 구현
