### PR TITLE
[#88]feat: 회원탈퇴 페이지 구현

### DIFF
--- a/src/components/auth/LoginPageClient.tsx
+++ b/src/components/auth/LoginPageClient.tsx
@@ -7,13 +7,11 @@ import Image from "next/image";
 import { useAuth } from "@/hooks/useAuth";
 import { socialLogin } from "@/services/authService";
 import { isPWA, isMobile } from "@/utils/deviceDetection";
-import { useMemberStore } from "@/stores/useMemberStore";
 
 export default function LoginPageClient() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { login } = useAuth();
-  const { fetchMember } = useMemberStore();
   const [isLoading, setIsLoading] = useState(false);
 
   // 브라우저 및 환경 감지 함수들
@@ -276,9 +274,6 @@ export default function LoginPageClient() {
 
         // 로그인 성공 시 토큰 저장
         login(response.accessToken, response.refreshToken);
-
-        // 회원 정보를 zustand store에 저장
-        await fetchMember();
 
         router.push("/transaction/my");
       } catch (error) {

--- a/src/components/group/GroupInfoPageClient.tsx
+++ b/src/components/group/GroupInfoPageClient.tsx
@@ -338,15 +338,15 @@ export default function GroupInfoPageClient() {
             <div className="text-center py-5 px-6">
               {groupInfo && groupInfo.members.length === 1 ? (
                 <>
-                  <p className="text-lg">마지막 인원이 떠날 경우</p>
-                  <p className="text-lg">그룹이 삭제됩니다.</p>
+                  <p className="text-lg">⚠️마지막 그룹원이 떠날 경우</p>
+                  <p className="text-lg">그룹이 삭제됩니다</p>
                   <br></br>
                   <p className="text-lg text-red-500">그래도 떠나시겠습니까?</p>
                 </>
               ) : (
                 <>
                   <p className="text-lg">그룹을 떠나기 전에</p>
-                  <p className="text-lg">새 그룹장을 지정해 주세요.</p>
+                  <p className="text-lg">새 그룹장을 지정해 주세요</p>
                 </>
               )}
             </div>

--- a/src/components/profile/ProfilePageClient.tsx
+++ b/src/components/profile/ProfilePageClient.tsx
@@ -1,18 +1,48 @@
 // components/profile/ProfilePageClient.tsx
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import TopBar from "@/components/ui/TopBar";
 import BottomBar from "@/components/ui/BottomBar";
 import { useMemberStore } from "@/stores/useMemberStore";
 import { useAuth } from "@/hooks/useAuth";
+import { withdrawMember, WithdrawalType } from "@/services/memberService";
+import {
+  getGroups,
+  getGroupInfo,
+  Group,
+  GroupInfo,
+} from "@/services/groupService";
 
 export default function ProfilePageClient() {
   const router = useRouter();
   const { member, fetchMember } = useMemberStore();
   const { logout, isLoggedIn } = useAuth();
+
+  // 모달 상태들
+  const [showWithdrawModal, setShowWithdrawModal] = useState(false);
+  const [showGroupLeaveModal, setShowGroupLeaveModal] = useState(false);
+  const [showLeaderSelectModal, setShowLeaderSelectModal] = useState(false);
+  const [showReasonModal, setShowReasonModal] = useState(false);
+  const [selectedReason, setSelectedReason] = useState<WithdrawalType | null>(
+    null
+  );
+  const [otherReason, setOtherReason] = useState("");
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  // 그룹 관련 상태
+  const [myGroups, setMyGroups] = useState<Group[]>([]);
+  const [currentGroupInfo, setCurrentGroupInfo] = useState<GroupInfo | null>(
+    null
+  );
+  const [isLoadingGroups, setIsLoadingGroups] = useState(false);
+  const [currentGroupIndex, setCurrentGroupIndex] = useState(0);
+  const [leaderTransferInfos, setLeaderTransferInfos] = useState<
+    Array<{ teamId: number; nextLeaderNickname: string }>
+  >([]);
+  const [selectedNewLeader, setSelectedNewLeader] = useState<string>("");
 
   // 회원 정보가 없으면 가져오기 (단, 로그인된 상태에서만)
   useEffect(() => {
@@ -20,6 +50,28 @@ export default function ProfilePageClient() {
       fetchMember();
     }
   }, [member, isLoggedIn, fetchMember]);
+
+  // 현재 그룹이 변경될 때마다 그룹 정보 조회
+  useEffect(() => {
+    const loadCurrentGroupInfo = async () => {
+      if (
+        showGroupLeaveModal &&
+        myGroups.length > 0 &&
+        currentGroupIndex < myGroups.length
+      ) {
+        const currentGroup = myGroups[currentGroupIndex];
+        try {
+          const groupInfo = await getGroupInfo(currentGroup.teamId);
+          setCurrentGroupInfo(groupInfo);
+        } catch (error) {
+          console.error(`그룹 ${currentGroup.title} 정보 조회 실패:`, error);
+          setCurrentGroupInfo(null);
+        }
+      }
+    };
+
+    loadCurrentGroupInfo();
+  }, [showGroupLeaveModal, myGroups, currentGroupIndex]);
 
   const handleProfileUpdate = () => {
     router.push("/profile/update");
@@ -43,13 +95,174 @@ export default function ProfilePageClient() {
     logout();
   };
 
-  const handleWithdrawal = () => {
-    if (
-      confirm("정말로 회원탈퇴를 하시겠습니까?\n이 작업은 되돌릴 수 없습니다.")
-    ) {
-      // 회원탈퇴 로직 구현 필요
-      console.log("회원탈퇴 처리");
+  // 회원탈퇴 버튼 클릭
+  const handleWithdrawalClick = () => {
+    setShowWithdrawModal(true);
+  };
+
+  // 첫 번째 모달에서 '네' 클릭 - 그룹 조회 및 그룹 탈퇴 모달로 이동
+  const handleFirstConfirm = async () => {
+    setIsLoadingGroups(true);
+
+    try {
+      const groupsResponse = await getGroups();
+      setMyGroups(groupsResponse.groups);
+      setCurrentGroupIndex(0);
+
+      setShowWithdrawModal(false);
+
+      if (groupsResponse.groups.length > 0) {
+        // 속한 그룹이 있으면 그룹 탈퇴 모달 표시
+        setShowGroupLeaveModal(true);
+      } else {
+        // 속한 그룹이 없으면 바로 탈퇴 사유 선택으로
+        setShowReasonModal(true);
+      }
+    } catch (error) {
+      alert("그룹 정보를 불러오는데 실패했습니다.");
+      console.error("그룹 조회 실패:", error);
+    } finally {
+      setIsLoadingGroups(false);
     }
+  };
+
+  // 그룹 탈퇴 처리 완료 후 탈퇴 사유 선택 모달로 이동
+  const handleGroupLeaveComplete = () => {
+    setShowGroupLeaveModal(false);
+    setShowReasonModal(true);
+  };
+
+  // 개별 그룹 처리 (그룹장이면 권한 이양 모달, 아니면 바로 다음 그룹)
+  const handleProcessCurrentGroup = () => {
+    if (!currentGroupInfo || currentGroupIndex >= myGroups.length) return;
+
+    const isLeader = currentGroupInfo.leaderNickname === member?.nickname;
+    const isLastMember = currentGroupInfo.members.length === 1;
+
+    if (isLeader && !isLastMember) {
+      // 그룹장이고 다른 멤버가 있는 경우 - 권한 이양 모달 표시
+      setShowLeaderSelectModal(true);
+    } else {
+      // 일반 멤버이거나 마지막 멤버인 경우 - 다음 그룹으로
+      moveToNextGroup();
+    }
+  };
+
+  // 그룹장 권한 이양 정보 저장 후 다음 그룹으로
+  const handleLeaderTransfer = (nextLeaderNickname: string) => {
+    if (!currentGroupInfo || !selectedNewLeader) return;
+
+    // 권한 이양 정보 저장
+    setLeaderTransferInfos((prev) => [
+      ...prev,
+      {
+        teamId: Number(currentGroupInfo.teamId),
+        nextLeaderNickname,
+      },
+    ]);
+
+    setShowLeaderSelectModal(false);
+    setSelectedNewLeader("");
+    moveToNextGroup();
+  };
+
+  // 다음 그룹으로 이동하거나 완료 처리
+  const moveToNextGroup = () => {
+    setCurrentGroupInfo(null);
+    if (currentGroupIndex < myGroups.length - 1) {
+      setCurrentGroupIndex((prev) => prev + 1);
+    } else {
+      // 모든 그룹 처리 완료
+      handleGroupLeaveComplete();
+    }
+  };
+
+  // 최종 회원탈퇴 실행
+  const handleFinalWithdraw = async () => {
+    if (!selectedReason) {
+      alert("탈퇴 사유를 선택해 주세요.");
+      return;
+    }
+
+    if (selectedReason === WithdrawalType.OTHER && !otherReason.trim()) {
+      alert("기타 사유를 입력해 주세요.");
+      return;
+    }
+
+    setIsProcessing(true);
+
+    try {
+      // 회원탈퇴 API 호출 (그룹 탈퇴도 함께 처리됨)
+      await withdrawMember({
+        withdrawalType: selectedReason,
+        otherReason:
+          selectedReason === WithdrawalType.OTHER ? otherReason : undefined,
+        leaderTransferInfos,
+      });
+
+      alert("회원탈퇴가 완료되었습니다.");
+      logout(); // 로그아웃 처리
+    } catch (error) {
+      alert(error || "회원탈퇴 중 오류가 발생했습니다.");
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  // 모달 닫기
+  const handleCloseModal = () => {
+    setShowWithdrawModal(false);
+    setShowGroupLeaveModal(false);
+    setShowLeaderSelectModal(false);
+    setShowReasonModal(false);
+    setSelectedReason(null);
+    setOtherReason("");
+    setMyGroups([]);
+    setCurrentGroupIndex(0);
+    setCurrentGroupInfo(null);
+    setLeaderTransferInfos([]);
+  };
+
+  // 탈퇴 사유 옵션들 (백엔드 enum과 일치)
+  const withdrawalReasons = [
+    { type: WithdrawalType.LOW_USAGE_FREQUENCY, label: "사용 빈도가 낮아요" },
+    {
+      type: WithdrawalType.LACK_OF_FEATURES,
+      label: "기능이 부족하거나 불편했어요",
+    },
+    {
+      type: WithdrawalType.USING_OTHER_SERVICE,
+      label: "다른 가계부 서비스를 이용하고 있어요",
+    },
+    {
+      type: WithdrawalType.DIFFICULT_UI_UX,
+      label: "UI/UX가 복잡하거나 어려웠어요",
+    },
+    {
+      type: WithdrawalType.FREQUENT_BUGS,
+      label: "오류나 버그가 자주 발생했어요",
+    },
+    { type: WithdrawalType.PRIVACY_CONCERN, label: "개인 정보가 걱정돼요" },
+    { type: WithdrawalType.OTHER, label: "기타(직접 입력)" },
+  ];
+
+  // 멤버 아이콘 색상 (그룹 정보 페이지와 동일)
+  const getMemberIconColor = (index: number) => {
+    const colors = [
+      "#F9F90C", // 노란색
+      "#94A7EF", // 보라색
+      "#FCC9EC", // 연분홍
+      "#45D076", // 연녹색
+    ];
+    return colors[index % colors.length];
+  };
+
+  // 새 그룹장 후보자 목록 (현재 그룹장 제외)
+  const getNewLeaderCandidates = () => {
+    if (!currentGroupInfo) return [];
+    return currentGroupInfo.members.filter(
+      (member) => member.nickname !== currentGroupInfo.leaderNickname
+    );
   };
 
   // 로그인 상태가 아니거나 회원 정보가 없는 경우
@@ -128,13 +341,382 @@ export default function ProfilePageClient() {
             로그아웃
           </button>
           <button
-            onClick={handleWithdrawal}
+            onClick={handleWithdrawalClick}
             className="w-full text-gray-400 py-3 px-4 rounded-lg text-sm font-medium hover:bg-gray-100 cursor-pointer transition-colors"
           >
             회원탈퇴
           </button>
         </div>
       </main>
+
+      {/* 첫 번째 모달: 회원탈퇴 확인 */}
+      {showWithdrawModal && (
+        <>
+          {/* 배경 오버레이 */}
+          <div
+            className="absolute top-0 left-0 right-0 bottom-0 bg-[#d9d9d9] opacity-50 flex h-screen items-center justify-center z-50"
+            onClick={handleCloseModal}
+          ></div>
+
+          {/* 모달 컨텐츠 */}
+          <div
+            className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white border-2 border-[#C7C3C3] rounded-[10px] p-2 w-[80%] z-50"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* 모달 메시지 */}
+            <div className="px-5 py-7 text-center">
+              <p className="text-lg leading-relaxed">
+                회원탈퇴를 하시겠습니까?
+              </p>
+            </div>
+
+            {/* 버튼들 */}
+            <div className="flex">
+              <button
+                onClick={handleFirstConfirm}
+                disabled={isLoadingGroups}
+                className="flex-1 mx-3 mb-4 py-3 text-white text-base font-light border rounded-[10px] bg-[#0EABFF] hover:bg-blue-600 cursor-pointer transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isLoadingGroups ? "처리 중..." : "네"}
+              </button>
+              <button
+                onClick={handleCloseModal}
+                disabled={isLoadingGroups}
+                className="flex-1 mx-3 mb-4 py-3 text-white text-base font-light border rounded-[10px] bg-[#D4D4D4] hover:bg-gray-400 cursor-pointer transition-colors disabled:cursor-not-allowed"
+              >
+                아니오
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* 두 번째 모달: 그룹 탈퇴 처리 */}
+      {showGroupLeaveModal && (
+        <>
+          {/* 배경 오버레이 */}
+          <div className="absolute top-0 left-0 right-0 bottom-0 bg-[#d9d9d9] opacity-50 flex h-screen items-center justify-center z-50"></div>
+
+          {/* 모달 컨텐츠 */}
+          <div
+            className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white border-2 border-[#C7C3C3] rounded-[10px] w-[85%] max-w-md z-50"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* 모달 헤더 */}
+            <div className="text-center py-5 px-6 border-b border-gray-200">
+              <p className="text-lg font-medium">그룹 떠나기</p>
+              <p className="text-sm text-gray-500 mt-2">
+                탈퇴 전에 모든 그룹을 떠나야 합니다
+              </p>
+            </div>
+
+            {/* 그룹 목록 또는 완료 메시지 */}
+            <div className="px-6 py-6">
+              {currentGroupIndex >= myGroups.length ? (
+                <div className="text-center py-8">
+                  <p className="text-green-600 font-medium">
+                    모든 그룹 처리 완료
+                  </p>
+                  <p className="text-sm text-gray-500 mt-2">
+                    이제 탈퇴 사유를 선택해 주세요
+                  </p>
+                </div>
+              ) : (
+                <div className="text-center">
+                  <p className="text-gray-600 mb-4">
+                    {currentGroupIndex + 1} / {myGroups.length}
+                  </p>
+                  <div className="bg-gray-50 rounded-lg p-4 mb-4">
+                    <p className="font-medium text-gray-800">
+                      {myGroups[currentGroupIndex]?.title}
+                    </p>
+                    <p className="text-sm text-gray-500 mt-1">
+                      현재 인원: {myGroups[currentGroupIndex]?.memberCount}명
+                    </p>
+                  </div>
+
+                  {/* 그룹 정보에 따른 메시지 */}
+                  {!currentGroupInfo ? (
+                    <p className="text-sm text-gray-600">
+                      그룹 정보를 확인하고 있습니다...
+                    </p>
+                  ) : (
+                    <div>
+                      {currentGroupInfo.leaderNickname === member?.nickname ? (
+                        currentGroupInfo.members.length === 1 ? (
+                          <div className="bg-red-50 border border-red-200 rounded-lg p-3">
+                            <p className="text-md mt-1">
+                              ⚠️ 마지막 그룹원이 떠날 경우
+                            </p>
+                            <p className="text-md text-red-600 mt-1">
+                              그룹이 삭제됩니다
+                            </p>
+                          </div>
+                        ) : (
+                          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3">
+                            <p className="text-sm text-yellow-600 mt-1">
+                              새 그룹장을 지정해 주세요
+                            </p>
+                          </div>
+                        )
+                      ) : (
+                        <p className="text-sm text-red-500">
+                          위 그룹을 떠나시겠습니까?
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* 버튼들 */}
+            <div className="flex px-6 pb-6 space-x-3 border-t border-gray-200 pt-4">
+              {currentGroupIndex >= myGroups.length ? (
+                <button
+                  onClick={handleGroupLeaveComplete}
+                  className="w-full py-3 px-4 bg-[#0EABFF] text-white rounded-[10px] font-light hover:bg-blue-600 cursor-pointer transition-colors"
+                >
+                  다음
+                </button>
+              ) : (
+                <>
+                  <button
+                    onClick={handleProcessCurrentGroup}
+                    disabled={!currentGroupInfo}
+                    className={`flex-1 py-3 px-4 rounded-[10px] font-light transition-colors ${
+                      currentGroupInfo
+                        ? "bg-[#0EABFF] text-white hover:bg-blue-600 cursor-pointer"
+                        : "bg-[#D4D4D4] text-white cursor-not-allowed"
+                    }`}
+                  >
+                    다음
+                  </button>
+                  <button
+                    onClick={handleCloseModal}
+                    className="flex-1 py-3 px-4 bg-[#D4D4D4] text-white rounded-[10px] font-light hover:bg-gray-400 cursor-pointer transition-colors"
+                  >
+                    취소
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* 세 번째 모달: 그룹장 선택 (권한 이양이 필요한 경우만) */}
+      {showLeaderSelectModal && currentGroupInfo && (
+        <>
+          {/* 배경 오버레이 */}
+          <div
+            className="absolute top-0 left-0 right-0 bottom-0 bg-[#d9d9d9] opacity-50 flex h-screen items-center justify-center z-50"
+            onClick={handleCloseModal}
+          ></div>
+
+          {/* 모달 컨텐츠 */}
+          <div
+            className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white border-2 border-[#C7C3C3] rounded-[10px] w-[80%] max-w-md z-50"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* 모달 헤더 */}
+            <div className="text-center py-5 px-6">
+              <p className="text-lg">새 그룹장을 지정해 주세요</p>
+              <p className="text-sm text-gray-500 mt-2">
+                그룹명: {currentGroupInfo.title}
+              </p>
+            </div>
+
+            {/* 멤버 목록 */}
+            <div className="px-6 pb-6">
+              <div className="max-h-80 overflow-y-auto">
+                {getNewLeaderCandidates().map((memberItem, index) => (
+                  <div
+                    key={memberItem.nickname}
+                    onClick={() => setSelectedNewLeader(memberItem.nickname)}
+                    className={`flex items-center space-x-2 p-2 rounded-[10px] cursor-pointer transition-colors border-white ${
+                      selectedNewLeader === memberItem.nickname
+                        ? "border-4 border-yellow-300"
+                        : "hover:bg-yellow-100"
+                    }`}
+                  >
+                    {/* 멤버 아이콘 */}
+                    <div className="w-8 h-8 rounded-full flex items-center justify-center overflow-hidden">
+                      {memberItem.profileImageUrl ? (
+                        <Image
+                          src={memberItem.profileImageUrl}
+                          alt={memberItem.nickname}
+                          width={64}
+                          height={64}
+                          className="w-full h-full object-cover"
+                          quality={100}
+                          unoptimized={true}
+                        />
+                      ) : (
+                        <div
+                          className="w-full h-full flex items-center justify-center text-white text-sm font-light"
+                          style={{
+                            backgroundColor: getMemberIconColor(index),
+                          }}
+                        >
+                          {memberItem.nickname.charAt(0).toUpperCase()}
+                        </div>
+                      )}
+                    </div>
+
+                    {/* 멤버 정보 */}
+                    <div className="flex-1">
+                      <span className="text-sm text-gray-700">
+                        {memberItem.nickname}
+                      </span>
+                    </div>
+
+                    {/* 선택 표시 */}
+                    {selectedNewLeader === memberItem.nickname && (
+                      <Image
+                        src="/images/group/그룹장_왕관.svg"
+                        alt="그룹장"
+                        width={20}
+                        height={20}
+                      />
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* 버튼들 */}
+            <div className="flex px-6 pb-6 space-x-3">
+              <button
+                onClick={() => handleLeaderTransfer(selectedNewLeader)}
+                disabled={!selectedNewLeader}
+                className={`flex-1 py-3 px-4 rounded-[10px] font-light transition-colors ${
+                  selectedNewLeader
+                    ? "bg-[#0EABFF] text-white hover:bg-blue-600 cursor-pointer"
+                    : "bg-[#D4D4D4] text-white cursor-not-allowed"
+                }`}
+              >
+                지정
+              </button>
+              <button
+                onClick={() => {
+                  setShowLeaderSelectModal(false);
+                  setSelectedNewLeader("");
+                }}
+                className="flex-1 py-3 px-4 bg-[#D4D4D4] text-white rounded-[10px] font-light hover:bg-gray-400 cursor-pointer transition-colors"
+              >
+                취소
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* 네 번째 모달: 탈퇴 사유 선택 */}
+      {showReasonModal && (
+        <>
+          {/* 배경 오버레이 */}
+          <div
+            className="absolute top-0 left-0 right-0 bottom-0 bg-[#d9d9d9] opacity-50 flex h-screen items-center justify-center z-50"
+            onClick={handleCloseModal}
+          ></div>
+
+          {/* 모달 컨텐츠 */}
+          <div
+            className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white border-2 border-[#C7C3C3] rounded-[10px] w-[85%] max-w-md z-50 max-h-[80vh] overflow-y-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* 모달 헤더 */}
+            <div className="text-center py-5 px-6">
+              <p className="text-lg">탈퇴 사유를 선택해 주세요</p>
+              <p className="text-sm text-[#11ABFF] mt-1">
+                이용 중 불편하셨던 점이 있다면 알려주세요
+              </p>
+              <p className="text-sm text-[#11ABFF] mt-1">
+                더 나은 서비스로 보답하겠습니다
+              </p>
+            </div>
+
+            {/* 탈퇴 사유 목록 */}
+            <div className="px-4">
+              <div className="space-y-1">
+                {withdrawalReasons.map((reason) => (
+                  <div key={reason.type}>
+                    <button
+                      onClick={() => setSelectedReason(reason.type)}
+                      className={`w-full text-left p-3 rounded-lg transition-colors text-sm cursor-pointer ${
+                        selectedReason === reason.type
+                          ? "bg-blue-50 border-2 border-[#0EABFF]"
+                          : "bg-gray-50 hover:bg-gray-100 border-2 border-transparent"
+                      }`}
+                    >
+                      <div className="flex items-center">
+                        <div
+                          className={`w-4 h-4 rounded-full border-2 mr-2 flex items-center justify-center ${
+                            selectedReason === reason.type
+                              ? "border-[#0EABFF] bg-[#0EABFF]"
+                              : "border-gray-300"
+                          }`}
+                        >
+                          {selectedReason === reason.type && (
+                            <div className="w-2 h-2 rounded-full bg-white"></div>
+                          )}
+                        </div>
+                        <span className="text-gray-700">{reason.label}</span>
+                      </div>
+                    </button>
+
+                    {/* 기타 사유 입력란 */}
+                    {selectedReason === WithdrawalType.OTHER &&
+                      reason.type === WithdrawalType.OTHER && (
+                        <div className="mt-2 ml-7">
+                          <textarea
+                            value={otherReason}
+                            onChange={(e) => {
+                              const value = e.target.value;
+                              if (value.length <= 50) {
+                                setOtherReason(value);
+                              }
+                            }}
+                            placeholder="구체적인 사유를 입력해 주세요 (최대 50자)"
+                            maxLength={50}
+                            className="w-full p-2 border border-gray-300 rounded-lg resize-none text-xs"
+                            rows={2}
+                          />
+                          <div className="text-right text-xs text-gray-500">
+                            {otherReason.length}/50
+                          </div>
+                        </div>
+                      )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* 버튼들 */}
+            <div className="flex px-6 pb-6 space-x-3 pt-3">
+              <button
+                onClick={handleFinalWithdraw}
+                disabled={isProcessing || !selectedReason}
+                className={`flex-1 py-3 px-4 rounded-[10px] font-light transition-colors ${
+                  selectedReason && !isProcessing
+                    ? "bg-[#0EABFF] text-white hover:bg-blue-600 cursor-pointer"
+                    : "bg-[#D4D4D4] text-white cursor-not-allowed"
+                }`}
+              >
+                {isProcessing ? "탈퇴 처리중..." : "탈퇴하기"}
+              </button>
+              <button
+                onClick={handleCloseModal}
+                disabled={isProcessing}
+                className="flex-1 py-3 px-4 bg-[#D4D4D4] text-white rounded-[10px] font-light hover:bg-gray-400 cursor-pointer transition-colors disabled:cursor-not-allowed"
+              >
+                취소
+              </button>
+            </div>
+          </div>
+        </>
+      )}
 
       <BottomBar />
     </div>

--- a/src/components/transaction/group/AddWritingGroupTransactionPageClient.tsx
+++ b/src/components/transaction/group/AddWritingGroupTransactionPageClient.tsx
@@ -260,7 +260,7 @@ export default function AddWritingGroupTransactionPageClient() {
           <input
             type="text"
             className="w-full p-2 border-b border-gray-300 focus:border-blue-500 text-sm outline-none"
-            placeholder="금액을 입력해주세요"
+            placeholder="금액을 입력해 주세요"
             value={formattedAmount()}
             onChange={handleAmountChange}
             onBlur={(e) => {
@@ -285,7 +285,7 @@ export default function AddWritingGroupTransactionPageClient() {
         <input
           type="text"
           className="w-full p-2 border-b border-gray-300 focus:border-blue-500 text-sm outline-none"
-          placeholder="내용을 입력해주세요"
+          placeholder="내용을 입력해 주세요(최대 50자)"
           value={content}
           onChange={handleContentChange}
         />

--- a/src/components/transaction/my/AddWritingMyTransactionPageClient.tsx
+++ b/src/components/transaction/my/AddWritingMyTransactionPageClient.tsx
@@ -219,7 +219,7 @@ export default function AddWritingMyTransactionPageClient() {
           <input
             type="text"
             className="w-full p-2 border-b border-gray-300 focus:border-blue-500 text-sm outline-none"
-            placeholder="금액을 입력해주세요"
+            placeholder="금액을 입력해 주세요"
             value={formattedAmount()}
             onChange={handleAmountChange}
             onBlur={(e) => {
@@ -244,7 +244,7 @@ export default function AddWritingMyTransactionPageClient() {
         <input
           type="text"
           className="w-full p-2 border-b border-gray-300 focus:border-blue-500 text-sm outline-none"
-          placeholder="내용을 입력해주세요"
+          placeholder="내용을 입력해 주세요(최대 50자)"
           value={content}
           onChange={handleContentChange}
         />

--- a/src/components/transaction/my/MyTransactionPageClient.tsx
+++ b/src/components/transaction/my/MyTransactionPageClient.tsx
@@ -1,7 +1,7 @@
 // components/transaction/my/MyTransactionPageClient.tsx
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import TopBar from "@/components/ui/TopBar";
@@ -12,9 +12,11 @@ import {
   MonthlyTransactionsResponse,
   TransactionSearchCriteria,
 } from "@/services/transactionService";
+import { useMemberStore } from "@/stores/useMemberStore";
 
 export default function MyTransactionPageClient() {
   const router = useRouter();
+  const { fetchMember } = useMemberStore();
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [isLoading, setIsLoading] = useState<boolean>(false); // 초기 로딩 제거
   const [response, setResponse] = useState<MonthlyTransactionsResponse>({
@@ -45,6 +47,8 @@ export default function MyTransactionPageClient() {
 
   // 통합된 useEffect로 중복 호출 방지
   useEffect(() => {
+    fetchMember();
+
     const year = selectedDate.getFullYear();
     const month = selectedDate.getMonth() + 1;
 
@@ -105,7 +109,7 @@ export default function MyTransactionPageClient() {
     return () => {
       clearTimeout(timeoutId);
     };
-  }, [selectedDate, currentCategoryFilter, allCategories.length]); // loadTransactions 의존성 완전 제거
+  }, [selectedDate, currentCategoryFilter, allCategories.length, fetchMember]); // loadTransactions 의존성 완전 제거
 
   // 날짜 변경 핸들러 (필터 유지)
   const handleDateChange = (date: Date) => {

--- a/src/components/transaction/my/MyTransactionPageClient.tsx
+++ b/src/components/transaction/my/MyTransactionPageClient.tsx
@@ -45,10 +45,17 @@ export default function MyTransactionPageClient() {
   // 필터 드롭다운 외부 클릭 감지를 위한 ref
   const categoryDropdownRef = useRef<HTMLDivElement>(null);
 
+  const hasFetchedMember = useRef(false);
+
+  useEffect(() => {
+    if (!hasFetchedMember.current) {
+      fetchMember();
+      hasFetchedMember.current = true;
+    }
+  }, []);
+
   // 통합된 useEffect로 중복 호출 방지
   useEffect(() => {
-    fetchMember();
-
     const year = selectedDate.getFullYear();
     const month = selectedDate.getMonth() + 1;
 
@@ -109,7 +116,7 @@ export default function MyTransactionPageClient() {
     return () => {
       clearTimeout(timeoutId);
     };
-  }, [selectedDate, currentCategoryFilter, allCategories.length, fetchMember]); // loadTransactions 의존성 완전 제거
+  }, [selectedDate, currentCategoryFilter, allCategories.length]); // loadTransactions 의존성 완전 제거
 
   // 날짜 변경 핸들러 (필터 유지)
   const handleDateChange = (date: Date) => {

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -34,6 +34,30 @@ export interface UpdateProfileResponse {
   gender: string;
 }
 
+// 탈퇴 사유 enum (백엔드와 일치)
+export enum WithdrawalType {
+  LOW_USAGE_FREQUENCY = "LOW_USAGE_FREQUENCY",
+  LACK_OF_FEATURES = "LACK_OF_FEATURES",
+  USING_OTHER_SERVICE = "USING_OTHER_SERVICE",
+  DIFFICULT_UI_UX = "DIFFICULT_UI_UX",
+  FREQUENT_BUGS = "FREQUENT_BUGS",
+  PRIVACY_CONCERN = "PRIVACY_CONCERN",
+  OTHER = "OTHER",
+}
+
+// 리더 권한 이양 정보 타입
+export interface LeaderTransferInfo {
+  teamId: number;
+  nextLeaderNickname: string;
+}
+
+// 회원탈퇴 요청 타입
+export interface WithdrawRequest {
+  withdrawalType: WithdrawalType;
+  otherReason?: string;
+  leaderTransferInfos: LeaderTransferInfo[];
+}
+
 // 회원 조회
 export const getMember = async (): Promise<Member> => {
   try {
@@ -88,6 +112,17 @@ export const updateProfile = async (
   try {
     const response = await patch("/api/members/profile", profileData);
     return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+// 회원탈퇴 API 함수
+export const withdrawMember = async (
+  request: WithdrawRequest
+): Promise<void> => {
+  try {
+    await patch("/api/members", request);
   } catch (error) {
     throw error;
   }


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[#1]feat: 로그인 페이지 UI 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #88 

**✅ Tasks**

- 회원탈퇴 페이지 구현
  - 참여 중인 그룹이 있을 경우 각 그룹 탈퇴 모달 구현
  - 그룹장일 경우 그룹장 위임 기능 구현
  - 탈퇴 사유 작성 모달에서 회원탈퇴 API 연동
- 회원 정보 데이터 조회 위치 수정
  - 로그인 페이지에서 개인 거래 내역 조회 페이지로 이동
  - ``useRef`` 사용해서 중복 호출 수정