### PR TITLE
[#91]feat: 로그인/회원가입, 회원탈퇴 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ logs
 
 # cache
 .swc/
+
+# Claude Code configuration
+CLAUDE.md

--- a/src/components/auth/LoginPageClient.tsx
+++ b/src/components/auth/LoginPageClient.tsx
@@ -262,6 +262,7 @@ export default function LoginPageClient() {
       setIsLoading(true);
 
       const requestData = {
+        email: userData.email,
         socialId:
           socialType === "KAKAO"
             ? userData.kakaoId.toString()

--- a/src/components/auth/LoginPageClient.tsx
+++ b/src/components/auth/LoginPageClient.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import { useAuth } from "@/hooks/useAuth";
 import { socialLogin } from "@/services/authService";
+import { integrateSocial } from "@/services/memberService";
 import { isPWA, isMobile } from "@/utils/deviceDetection";
 
 export default function LoginPageClient() {
@@ -13,6 +14,17 @@ export default function LoginPageClient() {
   const searchParams = useSearchParams();
   const { login } = useAuth();
   const [isLoading, setIsLoading] = useState(false);
+
+  // 소셜 연동 모달 상태
+  const [showIntegrateModal, setShowIntegrateModal] = useState(false);
+  const [showSignUpModal, setShowSignUpModal] = useState(false);
+  const [pendingSocialData, setPendingSocialData] = useState<{
+    socialEmail: string;
+    socialId: string;
+    socialType: string;
+    socialAccessToken: string;
+    existingSocialType?: string; // 연동 확인 모달에서만 사용
+  } | null>(null);
 
   // 브라우저 및 환경 감지 함수들
   const isKakaoTalkBrowser = () => {
@@ -262,7 +274,7 @@ export default function LoginPageClient() {
       setIsLoading(true);
 
       const requestData = {
-        email: userData.email,
+        socialEmail: userData.email,
         socialId:
           socialType === "KAKAO"
             ? userData.kakaoId.toString()
@@ -273,29 +285,38 @@ export default function LoginPageClient() {
       try {
         const response = await socialLogin(requestData);
 
+        // sameSocial이 false면 다른 소셜로 가입된 계정이 있음 → 연동 확인 모달
+        if (response.sameSocial === false) {
+          setPendingSocialData({
+            socialEmail: requestData.socialEmail,
+            socialId: requestData.socialId,
+            socialType: requestData.socialType,
+            socialAccessToken: userData.accessToken,
+            existingSocialType: response.existingSocialType,
+          });
+
+          setShowIntegrateModal(true);
+          return;
+        }
+
         // 로그인 성공 시 토큰 저장
         login(response.accessToken, response.refreshToken);
 
         router.push("/transaction/my");
       } catch (error) {
-        if (error.message === "존재하지 않는 회원입니다.") {
-          const socialLoginData = {
-            socialId:
-              socialType === "KAKAO"
-                ? userData.kakaoId.toString()
-                : userData.naverId.toString(),
-            socialType: socialType,
-            email: userData.email || null,
-            nickname: userData.nickname || null,
-            profileImage: userData.profileImage || null,
-          };
+        if (
+          error.message === "존재하지 않는 회원입니다." ||
+          error.message.includes("404")
+        ) {
+          // 가입된 계정이 없음 → 회원가입 안내 모달
+          setPendingSocialData({
+            socialEmail: requestData.socialEmail,
+            socialId: requestData.socialId,
+            socialType: requestData.socialType,
+            socialAccessToken: userData.accessToken,
+          });
 
-          sessionStorage.setItem(
-            "socialLoginData",
-            JSON.stringify(socialLoginData)
-          );
-
-          router.push("/sign-up/step1");
+          setShowSignUpModal(true);
         } else {
           alert(`로그인 실패: ${error.message}`);
         }
@@ -306,6 +327,126 @@ export default function LoginPageClient() {
       );
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  // 소셜 연동 확인 처리
+  const handleIntegrateConfirm = async () => {
+    if (!pendingSocialData) return;
+
+    try {
+      setIsLoading(true);
+      await integrateSocial({
+        socialEmail: pendingSocialData.socialEmail,
+        socialId: pendingSocialData.socialId,
+        socialType: pendingSocialData.socialType,
+      });
+
+      // 연동 성공 후 다시 로그인 시도
+      const response = await socialLogin({
+        socialEmail: pendingSocialData.socialEmail,
+        socialId: pendingSocialData.socialId,
+        socialType: pendingSocialData.socialType,
+      });
+
+      login(response.accessToken, response.refreshToken);
+      setShowIntegrateModal(false);
+      setPendingSocialData(null);
+      router.push("/transaction/my");
+    } catch (error) {
+      alert(`소셜 연동 실패: ${error.message}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 소셜 연동 취소 처리 (소셜 플랫폼에서 연결 끊기)
+  const handleIntegrateCancel = async () => {
+    if (!pendingSocialData) return;
+
+    // 카카오 또는 네이버 연결 해제
+    if (pendingSocialData.socialType === "KAKAO") {
+      await disconnectKakao();
+    } else if (pendingSocialData.socialType === "NAVER") {
+      await disconnectNaver();
+    }
+
+    setShowIntegrateModal(false);
+    setPendingSocialData(null);
+  };
+
+  // 회원가입 처리
+  const handleSignUp = () => {
+    if (!pendingSocialData) return;
+
+    const socialLoginData = {
+      socialId: pendingSocialData.socialId,
+      socialType: pendingSocialData.socialType,
+      socialEmail: pendingSocialData.socialEmail || null,
+      nickname: null,
+      profileImage: null,
+    };
+
+    sessionStorage.setItem("socialLoginData", JSON.stringify(socialLoginData));
+    setShowSignUpModal(false);
+    setPendingSocialData(null);
+    router.push("/sign-up/step1");
+  };
+
+  // 회원가입 취소 처리 (소셜 플랫폼에서 연결 끊기)
+  const handleSignUpCancel = async () => {
+    if (!pendingSocialData) return;
+
+    // 카카오 또는 네이버 연결 해제
+    if (pendingSocialData.socialType === "KAKAO") {
+      await disconnectKakao();
+    } else if (pendingSocialData.socialType === "NAVER") {
+      await disconnectNaver();
+    }
+
+    setShowSignUpModal(false);
+    setPendingSocialData(null);
+  };
+
+  // 카카오 연결 해제
+  const disconnectKakao = async () => {
+    if (!pendingSocialData?.socialAccessToken) return;
+
+    try {
+      await fetch("https://kapi.kakao.com/v1/user/unlink", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${pendingSocialData.socialAccessToken}`,
+        },
+      });
+    } catch (error) {
+      console.error("카카오 연결 해제 실패:", error);
+    }
+  };
+
+  // 네이버 연결 해제
+  const disconnectNaver = async () => {
+    if (!pendingSocialData?.socialAccessToken) return;
+
+    const NAVER_CLIENT_ID = process.env.NEXT_PUBLIC_NAVER_CLIENT_ID;
+    const NAVER_CLIENT_SECRET = process.env.NEXT_PUBLIC_NAVER_CLIENT_SECRET;
+
+    const naverRevokeUrl = `https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id=${NAVER_CLIENT_ID}&client_secret=${NAVER_CLIENT_SECRET}&access_token=${pendingSocialData.socialAccessToken}`;
+
+    try {
+      // 네이버는 CORS 제한으로 직접 호출이 어려울 수 있으므로 새 창으로 처리
+      const popup = window.open(
+        naverRevokeUrl,
+        "_blank",
+        "width=400,height=300"
+      );
+      if (popup) {
+        setTimeout(() => {
+          popup.close();
+        }, 10000);
+      }
+    } catch (error) {
+      console.error("네이버 연결 해제 실패:", error);
     }
   };
 
@@ -377,6 +518,124 @@ export default function LoginPageClient() {
           />
         </button>
       </div>
+
+      {/* 소셜 연동 확인 모달 */}
+      {showIntegrateModal && (
+        <>
+          {/* 배경 오버레이 */}
+          <div
+            className="absolute top-0 left-0 right-0 bottom-0 bg-[#d9d9d9] opacity-50 flex h-screen items-center justify-center z-50"
+            onClick={handleIntegrateCancel}
+          ></div>
+
+          {/* 모달 컨텐츠 */}
+          <div
+            className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white border-2 border-[#C7C3C3] rounded-[10px] p-6 w-[80%] max-w-sm z-50"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-lg font-semibold text-center mb-4">
+              SNS 간편 로그인 안내
+            </h3>
+            <p className="text-gray-600 text-center mb-6 text-sm leading-relaxed">
+              <span className="font-medium text-blue-500">
+                {pendingSocialData?.socialEmail}
+              </span>
+              <br />
+              이미{" "}
+              <span className="font-medium text-gray-800">
+                {pendingSocialData?.existingSocialType}
+              </span>{" "}
+              계정으로 가입된
+              <br />
+              회원 정보가 있습니다.
+              <br />
+              <br />
+              <span className="font-medium text-gray-800">
+                {pendingSocialData?.socialType}
+              </span>{" "}
+              계정과 연동하시겠습니까?
+              <br />
+            </p>
+
+            <div className="flex space-x-3">
+              <button
+                onClick={handleIntegrateCancel}
+                className="flex-1 py-3 px-4 text-[#0EABFF] font-light border-2 border-[#0EABFF] rounded-[10px] hover:bg-blue-50 transition-colors cursor-pointer"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleIntegrateConfirm}
+                disabled={isLoading}
+                className="flex-1 py-3 px-4 bg-[#0EABFF] text-white font-light rounded-[10px] hover:bg-blue-600 disabled:opacity-50 transition-colors cursor-pointer"
+              >
+                {isLoading ? "연동 중..." : "확인"}
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* 회원가입 안내 모달 */}
+      {showSignUpModal && (
+        <>
+          {/* 배경 오버레이 */}
+          <div
+            className="absolute top-0 left-0 right-0 bottom-0 bg-[#d9d9d9] opacity-50 flex h-screen items-center justify-center z-50"
+            onClick={handleSignUpCancel}
+          ></div>
+
+          {/* 모달 컨텐츠 */}
+          <div
+            className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white border-2 border-[#C7C3C3] rounded-[10px] p-6 w-[80%] max-w-sm z-50"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-lg font-semibold text-center mb-4">
+              SNS 간편 로그인 안내
+            </h3>
+            <p className="text-gray-600 text-center mb-6 text-md leading-relaxed">
+              <span className="font-medium text-gray-800">
+                {pendingSocialData?.socialType}
+              </span>{" "}
+              계정 정보로
+              <br />
+              일치하는 회원 정보를 찾을 수 없어요.
+              <br />
+              <br />
+              <span className="font-medium text-gray-800">
+                {pendingSocialData?.socialType}
+              </span>{" "}
+              계정 회원가입을 원하시는 경우
+              <br />
+              회원가입 버튼을 눌러주세요.
+              <br />
+              <br />
+              <span className="text-xs text-gray-500">
+                이미 다른 소셜로 가입한 회원이시라면
+                <br />
+                로그인 후 <span className="text-red-400">"마이페이지"</span>
+                <br />
+                메뉴에서 소셜 연결 설정을 진행해 주세요.
+              </span>
+            </p>
+
+            <div className="flex space-x-3">
+              <button
+                onClick={handleSignUpCancel}
+                className="flex-1 py-3 px-4 text-[#0EABFF] font-light border-2 border-[#0EABFF] rounded-[10px] hover:bg-blue-50 transition-colors cursor-pointer"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleSignUp}
+                className="flex-1 py-3 px-4 bg-[#0EABFF] text-white font-light rounded-[10px] hover:bg-blue-600 transition-colors cursor-pointer"
+              >
+                회원가입
+              </button>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/auth/LoginPageClient.tsx
+++ b/src/components/auth/LoginPageClient.tsx
@@ -613,9 +613,9 @@ export default function LoginPageClient() {
               <span className="text-xs text-gray-500">
                 이미 다른 소셜로 가입한 회원이시라면
                 <br />
-                로그인 후 <span className="text-red-400">"마이페이지"</span>
+                로그인 후 <span className="text-red-400">"마이페이지 > 프로필 수정"</span>
                 <br />
-                메뉴에서 소셜 연결 설정을 진행해 주세요.
+                메뉴에서 소셜 연동 설정을 진행해 주세요.
               </span>
             </p>
 

--- a/src/components/auth/SignUpAgreementClient.tsx
+++ b/src/components/auth/SignUpAgreementClient.tsx
@@ -11,6 +11,7 @@ export default function SignUpAgreementClient() {
     all: false,
     service: false,
     privacy: false,
+    aiLearning: false,
   });
   const [isLoading, setIsLoading] = useState(true);
   const [isNavigating, setIsNavigating] = useState(false);
@@ -36,18 +37,22 @@ export default function SignUpAgreementClient() {
       all: newValue,
       service: newValue,
       privacy: newValue,
+      aiLearning: newValue,
     });
   };
 
   // 개별 동의 처리
-  const handleAgreement = (key: "service" | "privacy") => {
+  const handleAgreement = (key: "service" | "privacy" | "aiLearning") => {
     const newAgreements = {
       ...agreements,
       [key]: !agreements[key],
     };
 
-    // 모든 약관이 체크되었는지 확인
-    newAgreements.all = newAgreements.service && newAgreements.privacy;
+    // 모든 약관이 체크되었는지 확인 (필수 + 선택사항 모두)
+    newAgreements.all =
+      newAgreements.service &&
+      newAgreements.privacy &&
+      newAgreements.aiLearning;
 
     setAgreements(newAgreements);
   };
@@ -66,6 +71,7 @@ export default function SignUpAgreementClient() {
           JSON.stringify({
             service: true,
             privacy: true,
+            aiLearning: agreements.aiLearning,
           })
         );
         sessionStorage.setItem("signupStep1Completed", "true");
@@ -191,6 +197,35 @@ export default function SignUpAgreementClient() {
               보기
             </Link>
           </div>
+        </div>
+
+        {/* AI 학습용 데이터 활용 동의 */}
+        <div className="mb-4">
+          <div className="flex items-center justify-between">
+            <div
+              className="flex items-center cursor-pointer"
+              onClick={() => handleAgreement("aiLearning")}
+            >
+              <div className="relative w-5 h-5 mr-2">
+                <div
+                  className={`w-5 h-5 border rounded-full transition-colors ${
+                    agreements.aiLearning
+                      ? "border-[#0EABFF]"
+                      : "border-gray-300"
+                  }`}
+                >
+                  {agreements.aiLearning && (
+                    <div className="absolute top-1 left-1 w-3 h-3 bg-[#0EABFF] rounded-full"></div>
+                  )}
+                </div>
+              </div>
+              <span className="text-sm">(선택) 가계부 데이터 활용 동의</span>
+            </div>
+          </div>
+          <p className="text-xs text-[#737373] mt-1 ml-8">
+            개인정보를 제거한 가계부 데이터를 AI 서비스 개선에 활용할 수
+            있습니다.
+          </p>
         </div>
       </div>
 

--- a/src/components/auth/SignUpInfoClient.tsx
+++ b/src/components/auth/SignUpInfoClient.tsx
@@ -3,7 +3,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { signUp } from "@/services/authService";
+import { signUp } from "@/services/memberService";
 
 export default function SignUpInfoClient() {
   const router = useRouter();
@@ -22,7 +22,7 @@ export default function SignUpInfoClient() {
   const [socialData, setSocialData] = useState<{
     socialId?: string;
     socialType?: string;
-    email?: string;
+    socialEmail?: string;
   }>({});
 
   // 접근 권한 확인
@@ -233,7 +233,7 @@ export default function SignUpInfoClient() {
       const signUpData = {
         socialId: socialData.socialId,
         socialType: socialData.socialType,
-        email: socialData.email,
+        socialEmail: socialData.socialEmail,
         name: userInfo.name.trim(),
         birthday: formattedBirthday,
         gender: userInfo.gender || null,
@@ -302,11 +302,11 @@ export default function SignUpInfoClient() {
         </h1>
 
         {/* 소셜 로그인 정보 표시 */}
-        {socialData.email && (
+        {socialData.socialEmail && (
           <div className="mb-6 p-3 bg-gray-50 rounded-md">
             <p className="text-sm text-gray-600">
               <span className="font-medium">연결된 계정 :</span>{" "}
-              {socialData.email}
+              {socialData.socialEmail}
             </p>
             <p className="text-xs text-gray-500 mt-1">
               {socialData.socialType === "KAKAO" ? "카카오" : "네이버"} 계정으로

--- a/src/components/auth/SignUpInfoClient.tsx
+++ b/src/components/auth/SignUpInfoClient.tsx
@@ -220,8 +220,11 @@ export default function SignUpInfoClient() {
         throw new Error("약관 동의 정보가 없습니다.");
       }
 
-      const { service: serviceAgreement, privacy: collectionAgreement } =
-        JSON.parse(agreementDataJson);
+      const {
+        service: serviceAgreement,
+        privacy: collectionAgreement,
+        aiLearning: aiLearningAgreement,
+      } = JSON.parse(agreementDataJson);
 
       // 생년월일 형식 변환
       let formattedBirthday = null;
@@ -239,6 +242,7 @@ export default function SignUpInfoClient() {
         gender: userInfo.gender || null,
         serviceAgreement,
         collectionAgreement,
+        aiLearningAgreement,
       };
 
       // API 서비스로 회원가입 요청

--- a/src/components/profile/ProfilePageClient.tsx
+++ b/src/components/profile/ProfilePageClient.tsx
@@ -8,7 +8,11 @@ import TopBar from "@/components/ui/TopBar";
 import BottomBar from "@/components/ui/BottomBar";
 import { useMemberStore } from "@/stores/useMemberStore";
 import { useAuth } from "@/hooks/useAuth";
-import { withdrawMember, WithdrawalType } from "@/services/memberService";
+import {
+  withdrawMember,
+  WithdrawalType,
+  updateAiLearningAgreement,
+} from "@/services/memberService";
 import {
   getGroups,
   getGroupInfo,
@@ -43,6 +47,9 @@ export default function ProfilePageClient() {
     Array<{ teamId: number; nextLeaderNickname: string }>
   >([]);
   const [selectedNewLeader, setSelectedNewLeader] = useState<string>("");
+
+  // AI 학습 동의 관련 상태
+  const [isUpdatingAiAgreement, setIsUpdatingAiAgreement] = useState(false);
 
   // 회원 정보가 없으면 가져오기 (단, 로그인된 상태에서만)
   useEffect(() => {
@@ -93,6 +100,24 @@ export default function ProfilePageClient() {
 
   const handleLogout = () => {
     logout();
+  };
+
+  // AI 학습 동의 토글 핸들러
+  const handleAiLearningAgreementToggle = async (newAgreement: boolean) => {
+    if (isUpdatingAiAgreement) return;
+
+    setIsUpdatingAiAgreement(true);
+    try {
+      await updateAiLearningAgreement(newAgreement);
+      // aiLearningAgreement 필드만 업데이트
+      useMemberStore
+        .getState()
+        .updateMember({ aiLearningAgreement: newAgreement });
+    } catch (error) {
+      alert(error || "AI 학습 동의 설정 변경 중 오류가 발생했습니다.");
+    } finally {
+      setIsUpdatingAiAgreement(false);
+    }
   };
 
   // 회원탈퇴 버튼 클릭
@@ -274,14 +299,14 @@ export default function ProfilePageClient() {
     <div className="h-screen bg-white flex flex-col">
       <TopBar />
 
-      <main className="flex-1 px-6 py-4 overflow-y-auto">
+      <main className="flex-1 px-6 py-3 overflow-y-auto">
         {/* Profile Section */}
-        <div className="text-center mb-6">
-          <h1 className="text-2xl text-black mb-4">
+        <div className="text-center mb-4">
+          <h1 className="text-2xl text-black mb-2">
             {member?.nickname || "사용자"}
           </h1>
 
-          <div className="w-24 h-24 mx-auto mb-6 relative">
+          <div className="w-24 h-24 mx-auto mb-4 relative">
             {member?.profileImageUrl ? (
               <Image
                 src={member.profileImageUrl}
@@ -312,7 +337,7 @@ export default function ProfilePageClient() {
         </div>
 
         {/* Policy & Help Section */}
-        <div className="bg-gray-50 rounded-lg text-sm shadow-sm mt-4">
+        <div className="bg-gray-50 rounded-lg text-sm shadow-sm mt-3">
           <div className="divide-y divide-gray-100">
             <button
               onClick={handlePrivacyPolicy}
@@ -329,6 +354,36 @@ export default function ProfilePageClient() {
               <span className="text-gray-600">서비스 이용약관</span>
               <span className="text-gray-400">›</span>
             </button>
+          </div>
+        </div>
+
+        {/* AI Learning Agreement Section */}
+        <div className="bg-gray-50 rounded-lg shadow-sm mt-3">
+          <div className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <span className="text-gray-600 text-sm">
+                  (선택) 가계부 데이터 활용 동의
+                </span>
+                <p className="text-xs text-gray-500 mt-1">
+                  개인정보를 제거한 가계부 데이터를
+                  <br />
+                  AI 서비스 개선에 활용합니다.
+                </p>
+              </div>
+              <label className="relative inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={member?.aiLearningAgreement || false}
+                  onChange={(e) =>
+                    handleAiLearningAgreementToggle(e.target.checked)
+                  }
+                  disabled={isUpdatingAiAgreement}
+                  className="sr-only peer"
+                />
+                <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#0EABFF]"></div>
+              </label>
+            </div>
           </div>
         </div>
 

--- a/src/components/profile/ProfilePageClient.tsx
+++ b/src/components/profile/ProfilePageClient.tsx
@@ -27,6 +27,7 @@ export default function ProfilePageClient() {
 
   // 모달 상태들
   const [showWithdrawModal, setShowWithdrawModal] = useState(false);
+  const [showWithdrawTypeModal, setShowWithdrawTypeModal] = useState(false);
   const [showGroupLeaveModal, setShowGroupLeaveModal] = useState(false);
   const [showLeaderSelectModal, setShowLeaderSelectModal] = useState(false);
   const [showReasonModal, setShowReasonModal] = useState(false);
@@ -35,6 +36,14 @@ export default function ProfilePageClient() {
   );
   const [otherReason, setOtherReason] = useState("");
   const [isProcessing, setIsProcessing] = useState(false);
+
+  // 탈퇴 방식 관련 상태
+  const [selectedWithdrawType, setSelectedWithdrawType] = useState<
+    "DORMANT" | "PERMANENT" | null
+  >(null);
+  const [aiLearningConsent, setAiLearningConsent] = useState<boolean | null>(
+    null
+  );
 
   // 그룹 관련 상태
   const [myGroups, setMyGroups] = useState<Group[]>([]);
@@ -125,8 +134,24 @@ export default function ProfilePageClient() {
     setShowWithdrawModal(true);
   };
 
-  // 첫 번째 모달에서 '네' 클릭 - 그룹 조회 및 그룹 탈퇴 모달로 이동
-  const handleFirstConfirm = async () => {
+  // 첫 번째 모달에서 '네' 클릭 - 탈퇴 방식 선택 모달로 이동
+  const handleFirstConfirm = () => {
+    setShowWithdrawModal(false);
+    setShowWithdrawTypeModal(true);
+  };
+
+  // 탈퇴 방식 선택 후 그룹 조회 및 다음 단계로 이동
+  const handleWithdrawTypeConfirm = async () => {
+    if (!selectedWithdrawType) {
+      alert("탈퇴 방식을 선택해 주세요.");
+      return;
+    }
+
+    if (selectedWithdrawType === "DORMANT" && aiLearningConsent === null) {
+      alert("데이터 보존 동의 여부를 선택해 주세요.");
+      return;
+    }
+
     setIsLoadingGroups(true);
 
     try {
@@ -134,7 +159,7 @@ export default function ProfilePageClient() {
       setMyGroups(groupsResponse.groups);
       setCurrentGroupIndex(0);
 
-      setShowWithdrawModal(false);
+      setShowWithdrawTypeModal(false);
 
       if (groupsResponse.groups.length > 0) {
         // 속한 그룹이 있으면 그룹 탈퇴 모달 표시
@@ -223,9 +248,16 @@ export default function ProfilePageClient() {
         otherReason:
           selectedReason === WithdrawalType.OTHER ? otherReason : undefined,
         leaderTransferInfos,
+        softDelete: selectedWithdrawType === "DORMANT",
+        dataRetentionConsent:
+          selectedWithdrawType === "DORMANT" && aiLearningConsent !== null
+            ? aiLearningConsent
+            : undefined,
       });
 
-      alert("회원탈퇴가 완료되었습니다.");
+      const withdrawTypeText =
+        selectedWithdrawType === "DORMANT" ? "휴면탈퇴" : "영구탈퇴";
+      alert(`${withdrawTypeText}가 완료되었습니다.`);
       logout(); // 로그아웃 처리
     } catch (error) {
       alert(error || "회원탈퇴 중 오류가 발생했습니다.");
@@ -237,6 +269,7 @@ export default function ProfilePageClient() {
   // 모달 닫기
   const handleCloseModal = () => {
     setShowWithdrawModal(false);
+    setShowWithdrawTypeModal(false);
     setShowGroupLeaveModal(false);
     setShowLeaderSelectModal(false);
     setShowReasonModal(false);
@@ -246,6 +279,8 @@ export default function ProfilePageClient() {
     setCurrentGroupIndex(0);
     setCurrentGroupInfo(null);
     setLeaderTransferInfos([]);
+    setSelectedWithdrawType(null);
+    setAiLearningConsent(null);
   };
 
   // 탈퇴 사유 옵션들 (백엔드 enum과 일치)
@@ -446,7 +481,167 @@ export default function ProfilePageClient() {
         </>
       )}
 
-      {/* 두 번째 모달: 그룹 탈퇴 처리 */}
+      {/* 두 번째 모달: 탈퇴 방식 선택 */}
+      {showWithdrawTypeModal && (
+        <>
+          {/* 배경 오버레이 */}
+          <div
+            className="absolute top-0 left-0 right-0 bottom-0 bg-[#d9d9d9] opacity-50 flex h-screen items-center justify-center z-50"
+            onClick={handleCloseModal}
+          ></div>
+
+          {/* 모달 컨텐츠 */}
+          <div
+            className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white border-2 border-[#C7C3C3] rounded-[10px] w-[85%] max-w-md z-50 max-h-[85vh] overflow-y-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* 모달 헤더 */}
+            <div className="text-center py-4 px-6">
+              <p className="text-lg font-medium">탈퇴 방식 선택</p>
+            </div>
+
+            {/* 탈퇴 방식 선택 */}
+            <div className="px-6 space-y-4">
+              {/* 휴면탈퇴 옵션 */}
+              <div
+                onClick={() => setSelectedWithdrawType("DORMANT")}
+                className={`border-2 rounded-lg p-4 cursor-pointer transition-colors ${
+                  selectedWithdrawType === "DORMANT"
+                    ? "border-[#0EABFF] bg-blue-50"
+                    : "border-gray-200 hover:border-gray-300"
+                }`}
+              >
+                <div className="flex items-start space-x-3">
+                  <div
+                    className={`w-5 h-5 rounded-full border-2 mt-0.5 flex items-center justify-center ${
+                      selectedWithdrawType === "DORMANT"
+                        ? "border-[#0EABFF] bg-[#0EABFF]"
+                        : "border-gray-300"
+                    }`}
+                  >
+                    {selectedWithdrawType === "DORMANT" && (
+                      <div className="w-2 h-2 rounded-full bg-white"></div>
+                    )}
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="font-medium text-gray-800">휴면탈퇴</h3>
+                    <p className="text-sm text-gray-600 mt-1">
+                      90일 후 회원정보와 가계부 데이터가 모두 삭제돼요.
+                    </p>
+                    <p className="text-sm text-gray-600">
+                      90일 이내 재가입 시 모든 데이터가 복구돼요.
+                    </p>
+                  </div>
+                </div>
+
+                {/* AI 학습 동의 옵션 (휴면탈퇴 선택 시에만 표시) */}
+                {selectedWithdrawType === "DORMANT" && (
+                  <div className="pt-2 border-t border-gray-200">
+                    <p className="text-sm font-medium text-gray-700">
+                      (선택) 가계부 데이터 활용 동의
+                    </p>
+                    <p className="text-xs text-gray-500 mb-1">
+                      개인정보를 제거한 가계부 데이터를 AI 서비스 개선에 5년간
+                      활용합니다.
+                      <br />
+                      동의 후에도 언제든지 데이터 삭제를 요청할 수 있어요.
+                    </p>
+                    <div className="space-y-2">
+                      <label className="flex items-center cursor-pointer">
+                        <input
+                          type="radio"
+                          name="aiConsent"
+                          checked={aiLearningConsent === true}
+                          onChange={() => setAiLearningConsent(true)}
+                          className="w-4 h-4 text-[#0EABFF] border-gray-300 focus:ring-[#0EABFF] cursor-pointer"
+                        />
+                        <span className="ml-2 text-sm text-gray-700">동의</span>
+                      </label>
+                      <label className="flex items-center cursor-pointer">
+                        <input
+                          type="radio"
+                          name="aiConsent"
+                          checked={aiLearningConsent === false}
+                          onChange={() => setAiLearningConsent(false)}
+                          className="w-4 h-4 text-[#0EABFF] border-gray-300 focus:ring-[#0EABFF] cursor-pointer"
+                        />
+                        <span className="ml-2 text-sm text-gray-700">거부</span>
+                      </label>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* 영구탈퇴 옵션 */}
+              <div
+                onClick={() => setSelectedWithdrawType("PERMANENT")}
+                className={`border-2 rounded-lg p-4 cursor-pointer transition-colors ${
+                  selectedWithdrawType === "PERMANENT"
+                    ? "border-[#0EABFF] bg-blue-50"
+                    : "border-gray-200 hover:border-gray-300"
+                }`}
+              >
+                <div className="flex items-start space-x-3">
+                  <div
+                    className={`w-5 h-5 rounded-full border-2 mt-0.5 flex items-center justify-center ${
+                      selectedWithdrawType === "PERMANENT"
+                        ? "border-[#0EABFF] bg-[#0EABFF]"
+                        : "border-gray-300"
+                    }`}
+                  >
+                    {selectedWithdrawType === "PERMANENT" && (
+                      <div className="w-2 h-2 rounded-full bg-white"></div>
+                    )}
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="font-medium text-gray-800">영구탈퇴</h3>
+                    <p className="text-sm text-gray-600 mt-1">
+                      회원정보와 가계부 데이터가 모두 삭제됩니다.
+                    </p>
+                    <p className="text-sm text-red-600">
+                      삭제된 데이터는 복구되지 않습니다.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* 버튼들 */}
+            <div className="flex px-6 pb-6 space-x-3 pt-5">
+              <button
+                onClick={handleWithdrawTypeConfirm}
+                disabled={
+                  !selectedWithdrawType ||
+                  isLoadingGroups ||
+                  (selectedWithdrawType === "DORMANT" &&
+                    aiLearningConsent === null)
+                }
+                className={`flex-1 py-3 px-4 rounded-[10px] font-light transition-colors ${
+                  selectedWithdrawType &&
+                  !(
+                    selectedWithdrawType === "DORMANT" &&
+                    aiLearningConsent === null
+                  ) &&
+                  !isLoadingGroups
+                    ? "bg-[#0EABFF] text-white hover:bg-blue-600 cursor-pointer"
+                    : "bg-[#D4D4D4] text-white cursor-not-allowed"
+                }`}
+              >
+                {isLoadingGroups ? "처리 중..." : "다음"}
+              </button>
+              <button
+                onClick={handleCloseModal}
+                disabled={isLoadingGroups}
+                className="flex-1 py-3 px-4 bg-[#D4D4D4] text-white rounded-[10px] font-light hover:bg-gray-400 cursor-pointer transition-colors disabled:cursor-not-allowed"
+              >
+                취소
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* 세 번째 모달: 그룹 탈퇴 처리 */}
       {showGroupLeaveModal && (
         <>
           {/* 배경 오버레이 */}
@@ -483,7 +678,7 @@ export default function ProfilePageClient() {
                   </p>
                   <div className="bg-gray-50 rounded-lg p-4 mb-4">
                     <p className="font-medium text-gray-800">
-                      {myGroups[currentGroupIndex]?.title}
+                      그룹명: {myGroups[currentGroupIndex]?.title}
                     </p>
                     <p className="text-sm text-gray-500 mt-1">
                       현재 인원: {myGroups[currentGroupIndex]?.memberCount}명
@@ -560,7 +755,7 @@ export default function ProfilePageClient() {
         </>
       )}
 
-      {/* 세 번째 모달: 그룹장 선택 (권한 이양이 필요한 경우만) */}
+      {/* 네 번째 모달: 그룹장 선택 (권한 이양이 필요한 경우만) */}
       {showLeaderSelectModal && currentGroupInfo && (
         <>
           {/* 배경 오버레이 */}
@@ -667,7 +862,7 @@ export default function ProfilePageClient() {
         </>
       )}
 
-      {/* 네 번째 모달: 탈퇴 사유 선택 */}
+      {/* 다섯 번째 모달: 탈퇴 사유 선택 */}
       {showReasonModal && (
         <>
           {/* 배경 오버레이 */}
@@ -682,13 +877,13 @@ export default function ProfilePageClient() {
             onClick={(e) => e.stopPropagation()}
           >
             {/* 모달 헤더 */}
-            <div className="text-center py-5 px-6">
-              <p className="text-lg">탈퇴 사유를 선택해 주세요</p>
+            <div className="text-center py-3 px-6">
+              <p className="text-lg">탈퇴 사유 선택</p>
               <p className="text-sm text-[#11ABFF] mt-1">
                 이용 중 불편하셨던 점이 있다면 알려주세요
               </p>
-              <p className="text-sm text-[#11ABFF] mt-1">
-                더 나은 서비스로 보답하겠습니다
+              <p className="text-sm text-[#11ABFF]">
+                더 나은 서비스로 보답할게요
               </p>
             </div>
 
@@ -749,7 +944,7 @@ export default function ProfilePageClient() {
             </div>
 
             {/* 버튼들 */}
-            <div className="flex px-6 pb-6 space-x-3 pt-3">
+            <div className="flex px-6 pb-6 space-x-3 pt-5">
               <button
                 onClick={handleFinalWithdraw}
                 disabled={isProcessing || !selectedReason}

--- a/src/components/profile/ProfileUpdatePageClient.tsx
+++ b/src/components/profile/ProfileUpdatePageClient.tsx
@@ -11,7 +11,10 @@ import {
   updateAvatar,
   checkNicknameAvailability,
   SocialType,
+  disconnectSocial,
+  integrateSocial,
 } from "@/services/memberService";
+import { isPWA, isMobile } from "@/utils/deviceDetection";
 import { useMemberStore } from "@/stores/useMemberStore";
 import { validateNickname, validateName } from "@/utils/validation";
 
@@ -38,6 +41,15 @@ export default function ProfileUpdatePageClient() {
   const [showAvatarModal, setShowAvatarModal] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  // 소셜 연동 상태
+  const [isUpdatingSocial, setIsUpdatingSocial] = useState(false);
+  const [pendingSocialData, setPendingSocialData] = useState<{
+    socialEmail: string;
+    socialId: string;
+    socialType: string;
+    socialAccessToken: string;
+  } | null>(null);
+
   // 기본 프로필 사진 URL들
   const defaultAvatars = [
     process.env.NEXT_PUBLIC_DEFAULT_AVATAR_1,
@@ -48,6 +60,20 @@ export default function ProfileUpdatePageClient() {
 
   // 현재 프로필 사진이 기본 사진인지 확인
   const isDefaultAvatar = profileImage && defaultAvatars.includes(profileImage);
+
+  // 브라우저 및 환경 감지 함수들
+  const isKakaoTalkBrowser = () => {
+    return /KAKAOTALK/i.test(navigator.userAgent);
+  };
+
+  const isEdge = () => {
+    return /Edg\//.test(navigator.userAgent);
+  };
+
+  // 리다이렉트를 사용해야 하는 경우 판단
+  const shouldUseRedirect = () => {
+    return isKakaoTalkBrowser() || isPWA() || isMobile();
+  };
 
   // 초기 데이터 로드 (Zustand 스토어를 통해 처리)
   useEffect(() => {
@@ -299,6 +325,424 @@ export default function ProfileUpdatePageClient() {
     }
   };
 
+  // 카카오 연동을 위한 로그인 함수
+  const handleKakaoIntegration = () => {
+    const KAKAO_REST_API_KEY = process.env.NEXT_PUBLIC_KAKAO_API_KEY;
+    const REDIRECT_URI = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI;
+
+    const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+
+    // PWA, 모바일, 카카오톡 브라우저는 리다이렉트
+    if (shouldUseRedirect()) {
+      window.location.href = kakaoAuthUrl;
+      return;
+    }
+
+    // PC 웹은 팝업
+    handleKakaoPopupIntegration();
+  };
+
+  // 카카오 팝업 연동
+  const handleKakaoPopupIntegration = () => {
+    const KAKAO_REST_API_KEY = process.env.NEXT_PUBLIC_KAKAO_API_KEY;
+    const REDIRECT_URI = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI;
+
+    const width = 500;
+    const height = 700;
+    const left = window.screenX + (window.outerWidth - width) / 2;
+    const top = window.screenY + (window.outerHeight - height) / 2;
+
+    const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+
+    let popupOptions = `width=${width},height=${height},left=${left},top=${top}`;
+
+    if (isEdge()) {
+      popupOptions +=
+        ",scrollbars=yes,resizable=yes,location=yes,menubar=no,toolbar=no";
+    }
+
+    const popup = window.open(kakaoAuthUrl, "kakaoIntegration", popupOptions);
+
+    if (!popup) {
+      alert("팝업이 차단되었습니다. 팝업 차단을 해제해주세요.");
+      setIsUpdatingSocial(false);
+      return;
+    }
+
+    if (isEdge()) {
+      popup.focus();
+      setTimeout(() => {
+        if (popup && (popup.closed || !popup.location)) {
+          popup.close();
+          window.location.href = kakaoAuthUrl;
+          return;
+        }
+      }, 1000);
+    }
+
+    const checkInterval = isEdge() ? 300 : 500;
+    const checkPopup = setInterval(() => {
+      if (!popup || popup.closed) {
+        clearInterval(checkPopup);
+        window.removeEventListener(
+          "message",
+          receiveKakaoIntegrationMessage,
+          false
+        );
+        setIsUpdatingSocial(false);
+      }
+    }, checkInterval);
+
+    setTimeout(() => {
+      clearInterval(checkPopup);
+      window.removeEventListener(
+        "message",
+        receiveKakaoIntegrationMessage,
+        false
+      );
+      setIsUpdatingSocial(false);
+    }, 30000);
+
+    window.addEventListener("message", receiveKakaoIntegrationMessage, false);
+
+    function receiveKakaoIntegrationMessage(event: MessageEvent) {
+      if (event.origin !== window.location.origin) return;
+
+      if (event.data.type === "kakaoLogin") {
+        if (event.data.success) {
+          // pendingSocialData에 저장 후 연동 처리
+          const socialData = {
+            socialEmail: event.data.userData.email,
+            socialId: event.data.userData.kakaoId,
+            socialType: "KAKAO",
+            socialAccessToken: event.data.userData.access_token || "",
+          };
+          setPendingSocialData(socialData);
+          handleSocialIntegration(socialData);
+        } else {
+          if (!event.data.cancelled) {
+            alert(`카카오 연동 실패: ${event.data.error}`);
+          }
+          setIsUpdatingSocial(false);
+        }
+
+        if (popup && !popup.closed) {
+          popup.close();
+        }
+
+        window.removeEventListener(
+          "message",
+          receiveKakaoIntegrationMessage,
+          false
+        );
+        clearInterval(checkPopup);
+      }
+    }
+  };
+
+  // 네이버 연동을 위한 로그인 함수
+  const handleNaverIntegration = () => {
+    const NAVER_CLIENT_ID = process.env.NEXT_PUBLIC_NAVER_CLIENT_ID;
+    const REDIRECT_URI = process.env.NEXT_PUBLIC_NAVER_REDIRECT_URI;
+    const STATE = Math.random().toString(36).substring(2, 15);
+
+    const naverAuthUrl = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&redirect_uri=${REDIRECT_URI}&state=${STATE}`;
+
+    // PWA, 모바일, 카카오톡 브라우저는 리다이렉트
+    if (shouldUseRedirect()) {
+      try {
+        localStorage.setItem("naverIntegrationState", STATE);
+      } catch (error) {
+        sessionStorage.setItem("naverIntegrationState", STATE);
+      }
+      window.location.href = naverAuthUrl;
+      return;
+    }
+
+    // PC 웹은 팝업
+    handleNaverPopupIntegration();
+  };
+
+  // 네이버 팝업 연동
+  const handleNaverPopupIntegration = () => {
+    const NAVER_CLIENT_ID = process.env.NEXT_PUBLIC_NAVER_CLIENT_ID;
+    const REDIRECT_URI = process.env.NEXT_PUBLIC_NAVER_REDIRECT_URI;
+    const STATE = Math.random().toString(36).substring(2, 15);
+
+    const width = 500;
+    const height = 700;
+    const left = window.screenX + (window.outerWidth - width) / 2;
+    const top = window.screenY + (window.outerHeight - height) / 2;
+
+    const naverAuthUrl = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&redirect_uri=${REDIRECT_URI}&state=${STATE}`;
+
+    const popup = window.open(
+      naverAuthUrl,
+      "naverIntegration",
+      `width=${width},height=${height},left=${left},top=${top}`
+    );
+
+    if (!popup) {
+      alert("팝업이 차단되었습니다. 팝업 차단을 해제해주세요.");
+      setIsUpdatingSocial(false);
+      return;
+    }
+
+    const checkPopup = setInterval(() => {
+      if (!popup || popup.closed) {
+        clearInterval(checkPopup);
+        window.removeEventListener(
+          "message",
+          receiveNaverIntegrationMessage,
+          false
+        );
+        setIsUpdatingSocial(false);
+      }
+    }, 500);
+
+    setTimeout(() => {
+      clearInterval(checkPopup);
+      window.removeEventListener(
+        "message",
+        receiveNaverIntegrationMessage,
+        false
+      );
+      setIsUpdatingSocial(false);
+    }, 30000);
+
+    window.addEventListener("message", receiveNaverIntegrationMessage, false);
+
+    function receiveNaverIntegrationMessage(event: MessageEvent) {
+      if (event.origin !== window.location.origin) return;
+
+      if (event.data.type === "naverLogin") {
+        if (event.data.success) {
+          // pendingSocialData에 저장 후 연동 처리
+          const socialData = {
+            socialEmail: event.data.userData.email,
+            socialId: event.data.userData.naverId,
+            socialType: "NAVER",
+            socialAccessToken: event.data.userData.access_token || "",
+          };
+          setPendingSocialData(socialData);
+          handleSocialIntegration(socialData);
+        } else {
+          if (!event.data.cancelled) {
+            alert(`네이버 연동 실패: ${event.data.error}`);
+          }
+          setIsUpdatingSocial(false);
+        }
+
+        if (popup && !popup.closed) {
+          popup.close();
+        }
+
+        window.removeEventListener(
+          "message",
+          receiveNaverIntegrationMessage,
+          false
+        );
+        clearInterval(checkPopup);
+      }
+    }
+  };
+
+  // 카카오 연결 해제 (프로필 수정용)
+  const disconnectKakaoProfile = async () => {
+    try {
+      // pendingSocialData에 카카오 토큰이 있으면 그것을 사용
+      if (
+        pendingSocialData?.socialType === "KAKAO" &&
+        pendingSocialData.socialAccessToken
+      ) {
+        await fetch("https://kapi.kakao.com/v1/user/unlink", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${pendingSocialData.socialAccessToken}`,
+          },
+        });
+        console.log("카카오 연결 해제 성공 (토큰 사용)");
+        return;
+      }
+
+      // pendingSocialData가 없으면 기존 방식 (카카오 SDK 사용)
+      if ((window as any).Kakao && (window as any).Kakao.Auth) {
+        // 현재 카카오 로그인 상태 확인
+        (window as any).Kakao.Auth.getStatusInfo()
+          .then((statusInfo: any) => {
+            if (statusInfo.status === "connected") {
+              // 카카오 앱과의 연결 해제
+              (window as any).Kakao.API.request({
+                url: "/v1/user/unlink",
+                success: (response: any) => {
+                  console.log("카카오 연결 해제 성공 (SDK 사용)");
+                },
+                fail: (error: any) => {
+                  console.warn("카카오 연결 해제 실패:", error);
+                },
+              });
+            }
+          })
+          .catch((error: any) => {
+            console.warn("카카오 상태 확인 실패:", error);
+          });
+      }
+    } catch (error) {
+      console.warn("카카오 연결 해제 실패:", error);
+    }
+  };
+
+  // 네이버 연결 해제 (프로필 수정용)
+  const disconnectNaverProfile = async () => {
+    try {
+      // pendingSocialData에 네이버 토큰이 있으면 그것을 사용
+      if (
+        pendingSocialData?.socialType === "NAVER" &&
+        pendingSocialData.socialAccessToken
+      ) {
+        const NAVER_CLIENT_ID = process.env.NEXT_PUBLIC_NAVER_CLIENT_ID;
+        const NAVER_CLIENT_SECRET = process.env.NEXT_PUBLIC_NAVER_CLIENT_SECRET;
+
+        const naverRevokeUrl = `https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id=${NAVER_CLIENT_ID}&client_secret=${NAVER_CLIENT_SECRET}&access_token=${pendingSocialData.socialAccessToken}`;
+
+        // 네이버는 CORS 제한으로 팝업으로 처리
+        const popup = window.open(
+          naverRevokeUrl,
+          "naverRevoke",
+          "width=400,height=300"
+        );
+
+        // 팝업이 닫히면 완료로 간주
+        const checkClosed = setInterval(() => {
+          if (popup?.closed) {
+            clearInterval(checkClosed);
+            console.log("네이버 연결 해제 완료 (토큰 사용)");
+          }
+        }, 1000);
+
+        return;
+      }
+
+      // pendingSocialData가 없으면 백엔드에서만 처리
+      console.log("네이버 연동 해제는 백엔드에서만 처리됩니다.");
+    } catch (error) {
+      console.warn("네이버 연결 해제 실패:", error);
+    }
+  };
+
+  // 소셜 연동 처리
+  const handleSocialIntegration = async (socialData: {
+    socialEmail: string;
+    socialId: string;
+    socialType: string;
+    socialAccessToken: string;
+  }) => {
+    try {
+      await integrateSocial({
+        socialEmail: socialData.socialEmail,
+        socialId: socialData.socialId,
+        socialType: socialData.socialType,
+      });
+
+      // 로컬 상태 업데이트
+      if (member?.socialTypes) {
+        const updatedSocialTypes = [
+          ...member.socialTypes,
+          socialData.socialType as SocialType,
+        ];
+        updateMember({ socialTypes: updatedSocialTypes });
+      }
+
+      alert(
+        `${getSocialDisplayName(
+          socialData.socialType as SocialType
+        )} 연동이 완료되었습니다.`
+      );
+
+      // 연동 완료 후 pendingSocialData 초기화
+      setPendingSocialData(null);
+    } catch (error) {
+      alert(
+        error ||
+          `${getSocialDisplayName(
+            socialData.socialType as SocialType
+          )} 연동 중 오류가 발생했습니다.`
+      );
+    } finally {
+      setIsUpdatingSocial(false);
+    }
+  };
+
+  // 소셜 연동 토글 핸들러
+  const handleSocialToggle = async (
+    socialType: SocialType,
+    checked: boolean
+  ) => {
+    if (isUpdatingSocial) return;
+
+    setIsUpdatingSocial(true);
+    try {
+      if (!checked) {
+        // 토글을 끄는 경우 = 연동 해제
+        if (member?.socialTypes && member.socialTypes.length <= 1) {
+          alert("마지막 연동 계정은 해제할 수 없습니다.");
+          setIsUpdatingSocial(false);
+          return;
+        }
+
+        const confirmed = confirm(
+          `${getSocialDisplayName(socialType)} 연동을 해제하시겠습니까?`
+        );
+        if (!confirmed) {
+          setIsUpdatingSocial(false);
+          return;
+        }
+
+        // 1. 백엔드에서 연동 해제
+        await disconnectSocial(socialType);
+
+        // 2. 프론트에서 소셜 언링크 (실패해도 계속 진행)
+        try {
+          if (socialType === SocialType.KAKAO) {
+            await disconnectKakaoProfile();
+          } else if (socialType === SocialType.NAVER) {
+            await disconnectNaverProfile();
+          }
+        } catch (unlinkError) {
+          console.warn("소셜 언링크 실패:", unlinkError);
+        }
+
+        // 3. 로컬 상태 업데이트
+        if (member?.socialTypes) {
+          const updatedSocialTypes = member.socialTypes.filter(
+            (type) => type !== socialType
+          );
+          updateMember({ socialTypes: updatedSocialTypes });
+        }
+
+        alert(`${getSocialDisplayName(socialType)} 연동이 해제되었습니다.`);
+        setIsUpdatingSocial(false);
+      } else {
+        // 토글을 켜는 경우 = 연동 추가
+        if (socialType === SocialType.KAKAO) {
+          handleKakaoIntegration();
+        } else if (socialType === SocialType.NAVER) {
+          handleNaverIntegration();
+        }
+        // setIsUpdatingSocial(false)는 각 연동 함수에서 처리
+        return;
+      }
+    } catch (error) {
+      alert(
+        error ||
+          `${getSocialDisplayName(
+            socialType
+          )} 연동 설정 중 오류가 발생했습니다.`
+      );
+      setIsUpdatingSocial(false);
+    }
+  };
+
   if (!member) {
     return <div className="h-screen bg-white flex flex-col"></div>;
   }
@@ -311,7 +755,7 @@ export default function ProfileUpdatePageClient() {
         <h1 className="text-xl font-light">프로필 수정</h1>
       </div>
 
-      <main className="flex-1 px-6 py-5 overflow-y-auto">
+      <main className="flex-1 px-4 py-5 overflow-y-auto max-w-sm mx-auto w-full">
         {/* 프로필 사진 섹션 */}
         <div className="text-center mb-5">
           <div className="relative w-24 h-24 mx-auto mb-4">
@@ -411,14 +855,14 @@ export default function ProfileUpdatePageClient() {
                 type="text"
                 value={nickname}
                 onChange={handleNicknameChange}
-                className="flex-1 p-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
+                className="flex-1 min-w-0 p-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
                 placeholder="닉네임을 입력하세요"
                 maxLength={6}
               />
               <button
                 type="button"
                 onClick={handleCheckNickname}
-                className="px-4 py-2 bg-gray-100 text-gray-600 rounded-lg border border-gray-300 hover:bg-gray-200 transition-colors cursor-pointer text-sm whitespace-nowrap"
+                className="px-3 py-2 bg-gray-100 text-gray-600 rounded-lg border border-gray-300 hover:bg-gray-200 transition-colors cursor-pointer text-sm whitespace-nowrap flex-shrink-0"
               >
                 중복 확인
               </button>
@@ -441,6 +885,17 @@ export default function ProfileUpdatePageClient() {
                 이미 사용 중인 닉네임입니다.
               </p>
             )}
+          </div>
+
+          {/* 이메일 */}
+          <div>
+            <label className="block text-sm text-gray-700 mb-1">이메일</label>
+            <input
+              type="email"
+              value={member.email}
+              disabled
+              className="w-full p-2 border border-gray-300 rounded-lg bg-gray-100 text-gray-500 cursor-not-allowed"
+            />
           </div>
 
           {/* 이름 */}
@@ -469,7 +924,7 @@ export default function ProfileUpdatePageClient() {
               type="date"
               value={birthday}
               onChange={(e) => setBirthday(e.target.value)}
-              className="w-full p-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
+              className="w-30 p-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
             />
           </div>
 
@@ -502,28 +957,65 @@ export default function ProfileUpdatePageClient() {
             </div>
           </div>
 
-          {/* 연결된 계정 */}
+          {/* 소셜 계정 연동 */}
           <div>
             <label className="block text-sm text-gray-700 mb-2">
-              연결된 계정
+              소셜 계정 연동 설정
             </label>
-            <div className="p-2 bg-gray-100 rounded-lg">
-              <div className="flex items-center gap-2">
-                <span
-                  className={`text-xs px-2 py-1 rounded ${getSocialStyleClass(
-                    member.socialType
-                  )}`}
-                >
-                  {getSocialDisplayName(member.socialType)}
-                </span>
-                <p className="text-gray-600">{member.email}</p>
+            <div className="space-y-3">
+              {/* 카카오 연동 */}
+              <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+                <div className="flex items-center gap-3">
+                  <span className="text-xs px-2 py-1 rounded bg-[#fae100] text-[#3f211e]">
+                    카카오
+                  </span>
+                  <span className="text-sm text-gray-600">카카오</span>
+                </div>
+                <label className="relative inline-flex items-center cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={
+                      member.socialTypes?.includes(SocialType.KAKAO) || false
+                    }
+                    onChange={(e) =>
+                      handleSocialToggle(SocialType.KAKAO, e.target.checked)
+                    }
+                    disabled={isUpdatingSocial}
+                    className="sr-only peer"
+                  />
+                  <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#0EABFF]"></div>
+                </label>
+              </div>
+
+              {/* 네이버 연동 */}
+              <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+                <div className="flex items-center gap-3">
+                  <span className="text-xs px-2 py-1 rounded bg-green-500 text-white">
+                    네이버
+                  </span>
+                  <span className="text-sm text-gray-600">네이버</span>
+                </div>
+                <label className="relative inline-flex items-center cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={
+                      member.socialTypes?.includes(SocialType.NAVER) || false
+                    }
+                    onChange={(e) =>
+                      handleSocialToggle(SocialType.NAVER, e.target.checked)
+                    }
+                    disabled={isUpdatingSocial}
+                    className="sr-only peer"
+                  />
+                  <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#0EABFF]"></div>
+                </label>
               </div>
             </div>
           </div>
         </div>
 
         {/* 수정 완료 버튼 */}
-        <div className="px-10 mt-8 mb-6">
+        <div className="px-10 mt-7 mb-6">
           <button
             onClick={handleUpdateProfile}
             disabled={isUpdateButtonDisabled()}

--- a/src/components/transaction/group/AddWritingGroupTransactionPageClient.tsx
+++ b/src/components/transaction/group/AddWritingGroupTransactionPageClient.tsx
@@ -44,7 +44,7 @@ export default function AddWritingGroupTransactionPageClient() {
 
   // 개인 거래 내역 동기화 상태 추가
   const [synchronizeTransaction, setSynchronizeTransaction] =
-    useState<boolean>(true);
+    useState<boolean>(false);
 
   // 카테고리 관련 상태
   const [categories, setCategories] = useState<Category[]>([]);

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -3,7 +3,7 @@ import { post } from "@/utils/apiClient";
 
 // 로그인 API
 export const socialLogin = async (data: {
-  email: string;
+  socialEmail: string;
   socialId: string;
   socialType: string;
 }) => {
@@ -13,9 +13,4 @@ export const socialLogin = async (data: {
 // 로그아웃 API
 export const logout = async () => {
   return post("/api/auth/logout");
-};
-
-// 회원가입 API
-export const signUp = async (signUpData: any) => {
-  return post("/api/members/sign-up", signUpData);
 };

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -3,6 +3,7 @@ import { post } from "@/utils/apiClient";
 
 // 로그인 API
 export const socialLogin = async (data: {
+  email: string;
   socialId: string;
   socialType: string;
 }) => {

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -58,6 +58,20 @@ export interface WithdrawRequest {
   leaderTransferInfos: LeaderTransferInfo[];
 }
 
+// 회원가입 API
+export const signUp = async (signUpData: any) => {
+  return post("/api/members/sign-up", signUpData);
+};
+
+// 소셜 연동 API
+export const integrateSocial = async (data: {
+  socialEmail: string;
+  socialId: string;
+  socialType: string;
+}) => {
+  return post("/api/members/integrate", data);
+};
+
 // 회원 조회
 export const getMember = async (): Promise<Member> => {
   try {

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -9,13 +9,14 @@ export enum SocialType {
 
 // 멤버 타입 정의
 export interface Member {
-  socialType: SocialType;
+  socialTypes: SocialType[]; // 연동된 소셜 계정 리스트
   email: string;
   name: string;
   nickname: string;
   birthday: string; // LocalDate는 문자열로 전송됨 (YYYY-MM-DD 형식)
   gender: string;
   profileImageUrl: string;
+  aiLearningAgreement: boolean; // AI 학습 활용 동의 여부
 }
 
 // 프로필 정보 업데이트 요청 타입
@@ -131,12 +132,34 @@ export const updateProfile = async (
   }
 };
 
+// AI 학습 동의 설정 업데이트
+export const updateAiLearningAgreement = async (
+  agreement: boolean
+): Promise<void> => {
+  try {
+    await patch(`/api/members/ai-learning-agreement?agreement=${agreement}`);
+  } catch (error) {
+    throw error;
+  }
+};
+
+// 소셜 연동 해제 API
+export const disconnectSocial = async (
+  socialType: SocialType
+): Promise<void> => {
+  try {
+    await del(`/api/members/unlink?socialType=${socialType}`);
+  } catch (error) {
+    throw error;
+  }
+};
+
 // 회원탈퇴 API 함수
 export const withdrawMember = async (
   request: WithdrawRequest
 ): Promise<void> => {
   try {
-    await patch("/api/members", request);
+    await del("/api/members", request);
   } catch (error) {
     throw error;
   }

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -57,6 +57,8 @@ export interface WithdrawRequest {
   withdrawalType: WithdrawalType;
   otherReason?: string;
   leaderTransferInfos: LeaderTransferInfo[];
+  softDelete: boolean; // 휴면탈퇴 여부 (true: 휴면탈퇴, false: 영구탈퇴)
+  dataRetentionConsent?: boolean; // AI 학습 활용 동의 (휴면탈퇴 시에만 선택사항)
 }
 
 // 회원가입 API

--- a/src/stores/useMemberStore.ts
+++ b/src/stores/useMemberStore.ts
@@ -11,13 +11,14 @@ export enum SocialType {
 
 // 멤버 타입 정의
 export interface Member {
-  socialType: SocialType;
+  socialTypes: SocialType[]; // 연동된 소셜 계정 리스트
   email: string;
   name: string;
   nickname: string;
   birthday: string;
   gender: string;
   profileImageUrl: string;
+  aiLearningAgreement: boolean;
 }
 
 interface MemberStore {


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[#1]feat: 로그인 페이지 UI 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #91 

**✅ Tasks**

- **로그인/회원가입 방식 수정**
  - 신규회원: 소셜 로그인 -> 회원가입 안내 모달 -> 회원가입 페이지
  - 기존회원(다른 소셜): 소셜 로그인 -> 기존 계정과의 소셜 연동 안내 모달 -> 로그인 성공
  - 기존회원(같은 소셜): 소셜 로그인 -> 로그인 성공
  - 휴면회원: 소셜 로그인 -> (휴면 해제 기능 구현 예정)
- **소셜 연동 기능 구현**
  - '마이페이지 > 프로필 수정'에서 소셜 연동 가능
- **회원탈퇴 방식 수정**
  - 휴면/영구탈퇴 선택 모달 추가
  - 휴면탈퇴: ``softDelete``값 ``true``, 90일 뒤 5년간 데이터 활용 동의/거부 체크박스 구현, 동의/거부 유형에 따라 ``dataRetentionConsent``값 ``true``or``false``
  - 영구탈퇴: ``softDelete``값 ``false``
- **AI 학습 활용 동의 기능 구현**
  - 약관 동의 페이지, 마이페이지에 AI 학습 활용 동의 선택지 추가
  - 마이페이지에선 토글로 선택 on/off 가능
- **거래 내역 동기화 체크박스 디폴트 ``false``로 수정**

**🙋🏻 More**
- 휴면 해제 기능 구현 예정