### PR TITLE
release: 비회원 체험 모드와 거래 필터/그룹 이탈 UI 개선 등

### DIFF
--- a/public/images/transaction/v2/돋보기_회색.svg
+++ b/public/images/transaction/v2/돋보기_회색.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16.6667 16.6667L12.9167 12.9167" stroke="#979CA1" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="8.74992" cy="8.75001" r="5.41667" stroke="#979CA1" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/api/auth/kakao/callback/route.ts
+++ b/src/app/api/auth/kakao/callback/route.ts
@@ -3,8 +3,18 @@ import { NextRequest } from "next/server";
 
 // 히스토리에 남지 않도록 location.replace를 사용하는 HTML 응답
 function redirectWithReplace(url: string) {
+  const safeUrl = JSON.stringify(url);
   return new Response(
-    `<html><head><script>window.location.replace("${url}");</script></head><body></body></html>`,
+    `<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <style>html,body{margin:0;height:100%;background:#ffffff;}</style>
+    <script>window.location.replace(${safeUrl});</script>
+  </head>
+  <body></body>
+</html>`,
     { headers: { "Content-Type": "text/html; charset=utf-8" } }
   );
 }

--- a/src/app/api/auth/naver/callback/route.ts
+++ b/src/app/api/auth/naver/callback/route.ts
@@ -3,8 +3,18 @@ import { NextRequest } from "next/server";
 
 // 히스토리에 남지 않도록 location.replace를 사용하는 HTML 응답
 function redirectWithReplace(url: string) {
+  const safeUrl = JSON.stringify(url);
   return new Response(
-    `<html><head><script>window.location.replace("${url}");</script></head><body></body></html>`,
+    `<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <style>html,body{margin:0;height:100%;background:#ffffff;}</style>
+    <script>window.location.replace(${safeUrl});</script>
+  </head>
+  <body></body>
+</html>`,
     { headers: { "Content-Type": "text/html; charset=utf-8" } }
   );
 }

--- a/src/app/group/create/page.tsx
+++ b/src/app/group/create/page.tsx
@@ -1,21 +1,9 @@
-// app/group/create/page.tsx
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import CreateGroupPageClient from "@/components/group/CreateGroupPageClient";
 
 export const metadata = {
   title: "그룹 생성",
 };
 
-export default async function CreateGroupPage() {
-  // 서버에서 인증 확인
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("refreshToken");
-
-  // 🔥 리프레시 토큰이 없으면 로그인 페이지로
-  if (!refreshToken) {
-    redirect("/");
-  }
-
+export default function CreateGroupPage() {
   return <CreateGroupPageClient />;
 }

--- a/src/app/group/create/success/page.tsx
+++ b/src/app/group/create/success/page.tsx
@@ -1,21 +1,9 @@
-// app/group/create/success/page.tsx
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import SuccessGroupPageClient from "@/components/group/SuccessGroupPageClient";
 
 export const metadata = {
   title: "그룹 생성 성공",
 };
 
-export default async function SuccessGroupPage() {
-  // 서버에서 인증 확인
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("refreshToken");
-
-  // 🔥 리프레시 토큰이 없으면 로그인 페이지로
-  if (!refreshToken) {
-    redirect("/");
-  }
-
+export default function SuccessGroupPage() {
   return <SuccessGroupPageClient />;
 }

--- a/src/app/group/info/[teamId]/leave/leader/page.tsx
+++ b/src/app/group/info/[teamId]/leave/leader/page.tsx
@@ -1,18 +1,9 @@
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import GroupLeaveLeaderTransferPageClient from "@/components/group/GroupLeaveLeaderTransferPageClient";
 
 export const metadata = {
   title: "그룹장 위임",
 };
 
-export default async function GroupLeaveLeaderTransferPage() {
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("refreshToken");
-
-  if (!refreshToken) {
-    redirect("/");
-  }
-
+export default function GroupLeaveLeaderTransferPage() {
   return <GroupLeaveLeaderTransferPageClient />;
 }

--- a/src/app/group/info/[teamId]/leave/page.tsx
+++ b/src/app/group/info/[teamId]/leave/page.tsx
@@ -1,18 +1,9 @@
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import GroupLeavePageClient from "@/components/group/GroupLeavePageClient";
 
 export const metadata = {
   title: "그룹 떠나기",
 };
 
-export default async function GroupLeavePage() {
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("refreshToken");
-
-  if (!refreshToken) {
-    redirect("/");
-  }
-
+export default function GroupLeavePage() {
   return <GroupLeavePageClient />;
 }

--- a/src/app/group/info/[teamId]/page.tsx
+++ b/src/app/group/info/[teamId]/page.tsx
@@ -1,19 +1,9 @@
-// app/group/info/[teamId]/page.tsx
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import GroupInfoPageClient from "@/components/group/GroupInfoPageClient";
 
 export const metadata = {
   title: "그룹 정보 수정",
 };
 
-export default async function GroupInfoPage() {
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("refreshToken");
-
-  if (!refreshToken) {
-    redirect("/");
-  }
-
+export default function GroupInfoPage() {
   return <GroupInfoPageClient />;
 }

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -1,21 +1,9 @@
-// app/group/page.tsx
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import GroupMainPageClient from "@/components/group/GroupMainPageClient";
 
 export const metadata = {
   title: "그룹 메인",
 };
 
-export default async function GroupPage() {
-  // 서버에서 인증 확인
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("refreshToken");
-
-  // 🔥 리프레시 토큰이 없으면 로그인 페이지로
-  if (!refreshToken) {
-    redirect("/");
-  }
-
+export default function GroupPage() {
   return <GroupMainPageClient />;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,6 +51,7 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const currentYear = new Date().getFullYear();
   // 서버에서 쿠키 읽기
   const cookieStore = await cookies();
   const isLoggedIn = !!cookieStore.get("accessToken");
@@ -107,7 +108,10 @@ export default async function RootLayout({
         <meta name="classification" content="Finance, Productivity" />
         <meta name="reply-to" content="dalcoomi.team@google.com" />
         <meta name="date" content="2025-10-01" />
-        <meta name="copyright" content="© 2025 달쿠미. All rights reserved." />
+        <meta
+          name="copyright"
+          content={`© ${currentYear} 달쿠미. All rights reserved.`}
+        />
         <meta property="og:locale" content="ko_KR" />
 
         {/* PWA 메타 태그 */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,3 @@
-// app/page.tsx (루트 페이지 - 랜딩 + 로그인)
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import RootPageClient from "@/components/auth/RootPageClient";
 import PWAInstallPrompt from "@/components/common/PWAInstallPrompt";
 
@@ -64,21 +61,10 @@ export const metadata = {
   },
 };
 
-export default async function RootPage() {
-  // 서버에서 인증 확인
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("refreshToken");
-
-  // 🔥 리프레시 토큰이 있으면 로그인된 상태로 간주 (액세스 토큰은 클라이언트에서 재발급)
-  if (refreshToken) {
-    redirect("/transaction/my");
-  }
-
-  // 로그인되지 않은 경우 랜딩 + 로그인 페이지 표시
+export default function RootPage() {
   return (
     <>
       <RootPageClient />
-      {/* PWA 설치 프롬프트 */}
       <PWAInstallPrompt />
     </>
   );

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,4 +1,3 @@
-// app/providers.tsx
 "use client";
 
 import { usePathname, useRouter } from "next/navigation";
@@ -18,18 +17,11 @@ export default function ClientProviders({
   const router = useRouter();
 
   useEffect(() => {
-    // 클라이언트에서 인증 상태 확인
     const clientAuth = isAuthenticated();
 
-    // 인증 상태 불일치 처리
     if (isLoggedIn !== clientAuth) {
-      // 미인증 상태에서 보호된 경로 접근
-      if (!clientAuth && pathname.startsWith("/transaction")) {
-        router.replace("/");
-      }
-      // 인증된 상태에서 루트 페이지 접근
-      else if (clientAuth && pathname === "/") {
-        router.replace("/transaction/my");
+      if (!clientAuth && pathname.startsWith("/profile")) {
+        router.replace("/?panel=login");
       }
     }
   }, [pathname, isLoggedIn, router]);

--- a/src/app/transaction/group/[teamId]/add/receipt/page.tsx
+++ b/src/app/transaction/group/[teamId]/add/receipt/page.tsx
@@ -1,21 +1,9 @@
-// app/transaction/group/add/receipt/page.tsx
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import AddReceiptGroupTransactionPageClient from "@/components/transaction/group/AddReceiptGroupTransactionPageClient";
 
 export const metadata = {
   title: "그룹 거래 내역 영수증 작성",
 };
 
-export default async function AddReceiptGroupTransactionPage() {
-  // 서버에서 인증 확인
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("refreshToken");
-
-  // 🔥 리프레시 토큰이 없으면 로그인 페이지로
-  if (!refreshToken) {
-    redirect("/");
-  }
-
+export default function AddReceiptGroupTransactionPage() {
   return <AddReceiptGroupTransactionPageClient />;
 }

--- a/src/app/transaction/group/[teamId]/add/writing/page.tsx
+++ b/src/app/transaction/group/[teamId]/add/writing/page.tsx
@@ -1,21 +1,9 @@
-// app/transaction/group/add/writing/page.tsx
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import AddGroupTransactionPageClient from "@/components/transaction/group/AddWritingGroupTransactionPageClient";
 
 export const metadata = {
   title: "그룹 거래 내역 직접 작성",
 };
 
-export default async function AddWritingGroupTransactionPage() {
-  // 서버에서 인증 확인
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("refreshToken");
-
-  // 🔥 리프레시 토큰이 없으면 로그인 페이지로
-  if (!refreshToken) {
-    redirect("/");
-  }
-
+export default function AddWritingGroupTransactionPage() {
   return <AddGroupTransactionPageClient />;
 }

--- a/src/app/transaction/group/[teamId]/page.tsx
+++ b/src/app/transaction/group/[teamId]/page.tsx
@@ -1,5 +1,3 @@
-﻿// app/transaction/group/[teamId]/page.tsx
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import GroupTransactionPageClient from "@/components/transaction/group/GroupTransactionPageClient";
 
@@ -16,15 +14,6 @@ export default async function GroupTransactionPage({
 
   if (!/^\d+$/.test(teamId)) {
     redirect("/transaction/group");
-  }
-
-  // 서버에서 인증 확인
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("refreshToken");
-
-  // 리프레시 토큰이 없으면 로그인 페이지로
-  if (!refreshToken) {
-    redirect("/");
   }
 
   return <GroupTransactionPageClient />;

--- a/src/app/transaction/group/[teamId]/update/page.tsx
+++ b/src/app/transaction/group/[teamId]/update/page.tsx
@@ -1,21 +1,9 @@
-// app/transaction/group/update/page.tsx
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import UpdateGroupTransactionPageClient from "@/components/transaction/group/UpdateGroupTransactionPageClient";
 
 export const metadata = {
-  title: "그룹 거래 내역 추가",
+  title: "그룹 거래 내역 수정",
 };
 
-export default async function UpdateGroupTransactionPage() {
-  // 서버에서 인증 확인
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("refreshToken");
-
-  // 🔥 리프레시 토큰이 없으면 로그인 페이지로
-  if (!refreshToken) {
-    redirect("/");
-  }
-
+export default function UpdateGroupTransactionPage() {
   return <UpdateGroupTransactionPageClient />;
 }

--- a/src/app/transaction/my/add/receipt/page.tsx
+++ b/src/app/transaction/my/add/receipt/page.tsx
@@ -1,21 +1,9 @@
-// app/transaction/my/add/receipt/page.tsx
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import AddReceiptMyTransactionPageClient from "@/components/transaction/my/AddReceiptMyTransactionPageClient";
 
 export const metadata = {
   title: "개인 거래 내역 영수증 작성",
 };
 
-export default async function AddReceiptMyTransactionPage() {
-  // 서버에서 인증 확인
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("refreshToken");
-
-  // 🔥 리프레시 토큰이 없으면 로그인 페이지로
-  if (!refreshToken) {
-    redirect("/");
-  }
-
+export default function AddReceiptMyTransactionPage() {
   return <AddReceiptMyTransactionPageClient />;
 }

--- a/src/app/transaction/my/add/writing/page.tsx
+++ b/src/app/transaction/my/add/writing/page.tsx
@@ -1,21 +1,9 @@
-// app/transaction/my/add/writing/page.tsx
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import AddMyTransactionPageClient from "@/components/transaction/my/AddWritingMyTransactionPageClient";
 
 export const metadata = {
   title: "개인 거래 내역 직접 작성",
 };
 
-export default async function AddWritingMyTransactionPage() {
-  // 서버에서 인증 확인
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("refreshToken");
-
-  // 🔥 리프레시 토큰이 없으면 로그인 페이지로
-  if (!refreshToken) {
-    redirect("/");
-  }
-
+export default function AddWritingMyTransactionPage() {
   return <AddMyTransactionPageClient />;
 }

--- a/src/app/transaction/my/page.tsx
+++ b/src/app/transaction/my/page.tsx
@@ -1,22 +1,9 @@
-// app/transaction/my/page.tsx
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import MyTransactionPageClient from "@/components/transaction/my/MyTransactionPageClient";
 
 export const metadata = {
   title: "개인 거래 내역",
 };
 
-// 서버 컴포넌트
-export default async function MyTransactionPage() {
-  // 서버에서 인증 확인
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("refreshToken");
-
-  // 🔥 리프레시 토큰이 없으면 로그인 페이지로
-  if (!refreshToken) {
-    redirect("/");
-  }
-
+export default function MyTransactionPage() {
   return <MyTransactionPageClient />;
 }

--- a/src/app/transaction/my/update/page.tsx
+++ b/src/app/transaction/my/update/page.tsx
@@ -1,21 +1,9 @@
-// app/transaction/my/update/page.tsx
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import UpdateMyTransactionPageClient from "@/components/transaction/my/UpdateMyTransactionPageClient";
 
 export const metadata = {
   title: "개인 거래 내역 수정",
 };
 
-export default async function UpdateMyTransactionPage() {
-  // 서버에서 인증 확인
-  const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("refreshToken");
-
-  // 🔥 리프레시 토큰이 없으면 로그인 페이지로
-  if (!refreshToken) {
-    redirect("/");
-  }
-
+export default function UpdateMyTransactionPage() {
   return <UpdateMyTransactionPageClient />;
 }

--- a/src/components/auth/RootPageClient.tsx
+++ b/src/components/auth/RootPageClient.tsx
@@ -1,11 +1,14 @@
-// components/auth/RootPageClient.tsx
 "use client";
 
 import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import LoginPageClient from "@/components/auth/LoginPageClient";
 import LandingContent from "@/components/landing/LandingContent";
+import MyTransactionPageClient from "@/components/transaction/my/MyTransactionPageClient";
+import ToastContainer from "@/components/ui/ToastContainer";
 
 export default function RootPageClient() {
+  const searchParams = useSearchParams();
   const [isDesktop, setIsDesktop] = useState(false);
 
   useEffect(() => {
@@ -16,39 +19,48 @@ export default function RootPageClient() {
     };
 
     updateWidth();
-    window.addEventListener('resize', updateWidth);
+    window.addEventListener("resize", updateWidth);
 
-    return () => window.removeEventListener('resize', updateWidth);
+    return () => window.removeEventListener("resize", updateWidth);
   }, []);
+
+  const isLoginPanelRequested = searchParams.get("panel") === "login";
+  const hasAuthCallbackParams =
+    searchParams.get("kakao_login") === "success" ||
+    searchParams.get("naver_login") === "success" ||
+    !!searchParams.get("user_data") ||
+    !!searchParams.get("error");
+  const isLoginPanel = isLoginPanelRequested || hasAuthCallbackParams;
 
   return (
     <div className="w-full h-screen bg-gray-100">
-      {/* 전체 레이아웃 컨테이너 */}
-      <div className="h-full flex justify-center" style={{ padding: isDesktop ? '0 2rem' : '0' }}>
+      <div
+        className="h-full flex justify-center"
+        style={{ padding: isDesktop ? "0 2rem" : "0" }}
+      >
         <div
           className="h-full bg-white flex"
           style={{
-            width: '100%',
-            maxWidth: isDesktop ? '1000px' : '390px',
-            boxShadow: isDesktop ? '0 25px 50px -12px rgb(0 0 0 / 0.25)' : 'none'
+            width: "100%",
+            maxWidth: isDesktop ? "1000px" : "390px",
+            boxShadow: isDesktop ? "0 25px 50px -12px rgb(0 0 0 / 0.25)" : "none",
           }}
         >
-          {/* 왼쪽: 랜딩 페이지 (화면 1024px 이상에서만 표시) */}
           {isDesktop && (
             <div className="h-full overflow-y-auto" style={{ flex: 1 }}>
               <LandingContent />
             </div>
           )}
 
-          {/* 오른쪽: 로그인 페이지 (390px 고정) */}
           <div
             className="h-full overflow-y-auto bg-white relative"
             style={{
-              width: isDesktop ? '390px' : '100%',
-              boxShadow: isDesktop ? 'none' : '0 10px 15px -3px rgb(0 0 0 / 0.1)'
+              width: isDesktop ? "390px" : "100%",
+              boxShadow: isDesktop ? "none" : "0 10px 15px -3px rgb(0 0 0 / 0.1)",
             }}
           >
-            <LoginPageClient />
+            <ToastContainer />
+            {isLoginPanel ? <LoginPageClient /> : <MyTransactionPageClient />}
           </div>
         </div>
       </div>

--- a/src/components/common/DemoModeTopBanner.tsx
+++ b/src/components/common/DemoModeTopBanner.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { isDemoMode } from "@/utils/demoMode";
+
+export default function DemoModeTopBanner() {
+  const router = useRouter();
+  const [isMounted, setIsMounted] = useState(false);
+  const [showBanner, setShowBanner] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+    setShowBanner(isDemoMode());
+  }, []);
+
+  if (!isMounted || !showBanner) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="sticky top-0 z-40 bg-gray-30/95 backdrop-blur px-4 pt-2 pb-1">
+        <div className="rounded-xl border border-sky-100 bg-white px-3 py-2 shadow-[0_1px_8px_rgba(15,23,42,0.06)]">
+          <div className="flex items-center justify-between gap-2">
+            <div className="min-w-0">
+              <div className="flex items-center gap-1.5">
+                <span className="demo-dot inline-block h-2 w-2 rounded-full bg-sky-500" />
+                <p className="text-[12px] font-semibold leading-4 text-slate-800">
+                  체험 모드
+                </p>
+              </div>
+              <p className="mt-1 text-[11px] leading-4 text-slate-500">
+                체험 데이터는 저장되지 않아요
+              </p>
+            </div>
+
+            <button
+              onClick={() => router.push("/?panel=login")}
+              className="shrink-0 rounded-lg bg-slate-900 px-3 py-1.5 text-[11px] font-semibold leading-4 text-white transition-colors hover:bg-slate-800 cursor-pointer"
+            >
+              로그인하고 실제로 사용하기
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <style jsx>{`
+        @keyframes demoDotBounce {
+          0%,
+          100% {
+            box-shadow: 0 0 0 0 rgba(14, 165, 233, 0.28);
+          }
+          40% {
+            box-shadow: 0 0 0 4px rgba(14, 165, 233, 0.08);
+          }
+        }
+
+        .demo-dot {
+          animation: demoDotBounce 1.4s ease-in-out infinite;
+        }
+      `}</style>
+    </>
+  );
+}

--- a/src/components/common/PWAInstallPrompt.tsx
+++ b/src/components/common/PWAInstallPrompt.tsx
@@ -91,7 +91,7 @@ export default function PWAInstallPrompt() {
   // iOS용 안내 UI
   if (isIOS) {
     return (
-      <div className="fixed bottom-0 left-0 right-0 z-50 animate-slide-up">
+      <div className="fixed bottom-0 left-0 right-0 z-[120] animate-slide-up">
         <div className="bg-white rounded-t-2xl shadow-2xl p-6 border-t-4 border-blue-500 mx-auto max-w-[390px]">
           <div className="flex justify-between items-start mb-4">
             <div className="flex items-center space-x-3">
@@ -166,7 +166,7 @@ export default function PWAInstallPrompt() {
 
   // Android Chrome/Edge용 커스텀 프롬프트
   return (
-    <div className="fixed bottom-14 left-1/2 transform -translate-x-1/2 z-50 w-[90%] max-w-md animate-slide-up">
+    <div className="fixed bottom-14 left-1/2 transform -translate-x-1/2 z-[120] w-[90%] max-w-md animate-slide-up">
       <div className="bg-white rounded-xl shadow-2xl p-5 border border-gray-200">
         <div className="flex items-start space-x-4 mb-4">
           <img

--- a/src/components/group/GroupLeavePageClient.tsx
+++ b/src/components/group/GroupLeavePageClient.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import { useParams, useRouter } from "next/navigation";
-import BottomButton from "@/components/ui/BottomButton";
 import {
   getGroupInfo,
   getGroups,
@@ -181,12 +180,26 @@ export default function GroupLeavePageClient() {
         </div>
       </div>
 
-      <BottomButton
-        text={isSubmitting ? "처리 중..." : "떠나기"}
-        onClick={handleFirstLeaveConfirm}
-        disabled={isSubmitting}
-        className="pb-4"
-      />
+      <div className="pb-4 px-5">
+        <div className="mx-auto flex w-full max-w-[390px] items-center gap-2">
+          <button
+            type="button"
+            onClick={handleFirstLeaveConfirm}
+            disabled={isSubmitting}
+            className="h-12 flex-1 cursor-pointer rounded-xl border border-gray-800 bg-white text-body1-semibold text-gray-900 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isSubmitting ? "처리 중..." : "떠나기"}
+          </button>
+          <button
+            type="button"
+            onClick={handleBackToGroupInfo}
+            disabled={isSubmitting}
+            className="h-12 flex-[1.85] cursor-pointer rounded-xl bg-gray-900 text-body1-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            취소하기
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/landing/LandingContent.tsx
+++ b/src/components/landing/LandingContent.tsx
@@ -7,6 +7,7 @@ import { useToastStore } from "@/stores/useToastStore";
 export default function LandingContent() {
   const scrollRef = useRef<HTMLDivElement>(null);
   const addToast = useToastStore((state) => state.addToast);
+  const currentYear = new Date().getFullYear();
   const [openFaqIndex, setOpenFaqIndex] = useState<number | null>(null);
   const [deferredPrompt, setDeferredPrompt] =
     useState<BeforeInstallPromptEvent | null>(null);
@@ -433,7 +434,7 @@ export default function LandingContent() {
                   개인정보처리방침
                 </a>
                 <p className="text-[10px] text-gray-500">
-                  Copyright © 2025 달쿠미. All rights reserved.
+                  {`Copyright © ${currentYear} 달쿠미. All rights reserved.`}
                 </p>
               </div>
             </div>

--- a/src/components/skeletons/TransactionPageSkeleton.tsx
+++ b/src/components/skeletons/TransactionPageSkeleton.tsx
@@ -75,10 +75,7 @@ export default function TransactionPageSkeleton() {
 
       {/* 거래 내역 목록 영역 */}
       <div className="bg-white flex-1">
-        <TransactionFilter
-          showCategoryFilter={false}
-          onCategoryToggle={() => {}}
-        />
+        <TransactionFilter />
         {Array.from({ length: 3 }).map((_, index) => (
           <TransactionItemSkeleton key={index} />
         ))}

--- a/src/components/transaction/group/GroupTransactionPageClient.tsx
+++ b/src/components/transaction/group/GroupTransactionPageClient.tsx
@@ -12,6 +12,9 @@ import TransactionFilter from "@/components/transaction/v2/TransactionFilter";
 import SortBottomSheet, {
   SortOption,
 } from "@/components/transaction/v2/SortBottomSheet";
+import FilterBottomSheet, {
+  FilterDraftState,
+} from "@/components/transaction/v2/FilterBottomSheet";
 import TransactionTypeToggle, {
   ViewMode,
 } from "@/components/transaction/v2/TransactionTypeToggle";
@@ -34,6 +37,9 @@ import Skeleton from "@/components/skeletons/Skeleton";
 import Sidebar from "@/components/ui/Sidebar";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { BRAND_COLORS } from "@/constants/brandColors";
+import { getTeamCategories } from "@/services/categoryService";
+import DemoModeTopBanner from "@/components/common/DemoModeTopBanner";
+import { isDemoMode } from "@/utils/demoMode";
 
 let cachedGroupModalList: Group[] = [];
 
@@ -79,18 +85,47 @@ export default function GroupTransactionPageClient() {
   const [selectedSort, setSelectedSort] = useState<SortOption>("최신순");
   const [isSortModalMounted, setIsSortModalMounted] = useState(false);
   const [showSortModal, setShowSortModal] = useState(false);
+  const [isFilterModalMounted, setIsFilterModalMounted] = useState(false);
+  const [showFilterModal, setShowFilterModal] = useState(false);
+  const [appliedFilter, setAppliedFilter] = useState<FilterDraftState>({
+    type: "ALL",
+    categoryNames: [],
+    creatorNicknames: [],
+  });
+  const [draftFilter, setDraftFilter] = useState<FilterDraftState>({
+    type: "ALL",
+    categoryNames: [],
+    creatorNicknames: [],
+  });
+  const [categoriesByType, setCategoriesByType] = useState<{
+    ALL: string[];
+    EXPENSE: string[];
+    INCOME: string[];
+  }>({
+    ALL: [],
+    EXPENSE: [],
+    INCOME: [],
+  });
 
   // 날짜 관련 상태
   const getSavedDate = (): Date => {
     if (typeof window === "undefined") return new Date();
     const saved = sessionStorage.getItem(`group-transaction-date-${teamId}`);
+    const now = new Date();
     if (saved) {
       const parsed = new Date(saved);
       if (!isNaN(parsed.getTime())) {
+        if (
+          isDemoMode() &&
+          (parsed.getFullYear() !== now.getFullYear() ||
+            parsed.getMonth() !== now.getMonth())
+        ) {
+          return now;
+        }
         return parsed;
       }
     }
-    return new Date();
+    return now;
   };
 
   const [selectedDate, setSelectedDate] = useState<Date>(getSavedDate());
@@ -102,9 +137,6 @@ export default function GroupTransactionPageClient() {
     transactions: [],
   });
   const [groupInfo, setGroupInfo] = useState<GroupInfo | null>(null);
-
-  // 필터링 관련 상태
-  const [currentCategoryFilter] = useState<string | null>(null);
 
   // 중복 호출 방지를 위한 ref
   const lastRequestRef = useRef<string>("");
@@ -118,6 +150,9 @@ export default function GroupTransactionPageClient() {
 
   const closeModalTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const sortModalCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const filterModalCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const hasFetchedMember = useRef(false);
   const hasOpenedFromQueryRef = useRef(false);
   const modalDragStartYRef = useRef<number | null>(null);
@@ -190,6 +225,9 @@ export default function GroupTransactionPageClient() {
       if (sortModalCloseTimerRef.current) {
         clearTimeout(sortModalCloseTimerRef.current);
       }
+      if (filterModalCloseTimerRef.current) {
+        clearTimeout(filterModalCloseTimerRef.current);
+      }
     };
   }, []);
 
@@ -222,6 +260,56 @@ export default function GroupTransactionPageClient() {
       isCancelled = true;
     };
   }, [isValidTeamId, teamId]);
+
+  useEffect(() => {
+    if (!teamId || !isValidTeamId) return;
+
+    const fetchCategories = async () => {
+      const numericTeamId = Number(teamId);
+      const [expenseCategories, incomeCategories] = await Promise.all([
+        getTeamCategories(numericTeamId, "EXPENSE"),
+        getTeamCategories(numericTeamId, "INCOME"),
+      ]);
+
+      const expenseNames = expenseCategories.map((category) => category.name);
+      const incomeNames = incomeCategories.map((category) => category.name);
+      const all = Array.from(new Set([...expenseNames, ...incomeNames]));
+
+      setCategoriesByType({
+        ALL: all,
+        EXPENSE: expenseNames,
+        INCOME: incomeNames,
+      });
+
+      const defaultFilter: FilterDraftState = {
+        type: "ALL",
+        categoryNames: all,
+        creatorNicknames: [],
+      };
+
+      setAppliedFilter(defaultFilter);
+      setDraftFilter(defaultFilter);
+    };
+
+    void fetchCategories();
+  }, [isValidTeamId, teamId]);
+
+  useEffect(() => {
+    const allCreatorNicknames = (groupInfo?.members ?? []).map(
+      (memberInfo) => memberInfo.nickname,
+    );
+
+    if (allCreatorNicknames.length === 0) return;
+
+    setAppliedFilter((prev) => ({
+      ...prev,
+      creatorNicknames: allCreatorNicknames,
+    }));
+    setDraftFilter((prev) => ({
+      ...prev,
+      creatorNicknames: allCreatorNicknames,
+    }));
+  }, [groupInfo?.members]);
 
   // 사이드바 메뉴 핸들러
   const handleMenuClick = () => {
@@ -303,9 +391,7 @@ export default function GroupTransactionPageClient() {
 
     const year = selectedDate.getFullYear();
     const month = selectedDate.getMonth() + 1;
-    const requestKey = `${teamId}-${year}-${month}-${
-      currentCategoryFilter || ""
-    }`;
+    const requestKey = `${teamId}-${year}-${month}`;
 
     if (
       isRequestInProgressRef.current &&
@@ -333,7 +419,6 @@ export default function GroupTransactionPageClient() {
             teamId: parseInt(teamId),
             year,
             month,
-            categoryName: currentCategoryFilter,
           };
 
           const response = await getTransactions(criteria);
@@ -362,14 +447,28 @@ export default function GroupTransactionPageClient() {
     return () => {
       clearTimeout(timeoutId);
     };
-  }, [isValidTeamId, selectedDate, currentCategoryFilter, teamId]);
+  }, [isValidTeamId, selectedDate, teamId]);
 
   // 필터링된 거래 내역 가져오기
   const getFilteredTransactions = () => {
     const filtered = response.transactions.filter((transaction) => {
       if (
-        currentCategoryFilter &&
-        transaction.categoryName !== currentCategoryFilter
+        appliedFilter.type !== "ALL" &&
+        transaction.transactionType !== appliedFilter.type
+      ) {
+        return false;
+      }
+
+      if (
+        appliedFilter.categoryNames.length > 0 &&
+        !appliedFilter.categoryNames.includes(transaction.categoryName)
+      ) {
+        return false;
+      }
+
+      if (
+        appliedFilter.creatorNicknames.length > 0 &&
+        !appliedFilter.creatorNicknames.includes(transaction.creatorNickname)
       ) {
         return false;
       }
@@ -496,6 +595,56 @@ export default function GroupTransactionPageClient() {
   const handleSelectSort = (sort: SortOption) => {
     setSelectedSort(sort);
     handleCloseSortModal();
+  };
+
+  const handleOpenFilterModal = () => {
+    setIsFloatingMenuOpen(false);
+
+    if (filterModalCloseTimerRef.current) {
+      clearTimeout(filterModalCloseTimerRef.current);
+      filterModalCloseTimerRef.current = null;
+    }
+
+    setDraftFilter(appliedFilter);
+
+    if (!isFilterModalMounted) {
+      setIsFilterModalMounted(true);
+      requestAnimationFrame(() => setShowFilterModal(true));
+      return;
+    }
+
+    setShowFilterModal(true);
+  };
+
+  const handleCloseFilterModal = () => {
+    setShowFilterModal(false);
+
+    if (filterModalCloseTimerRef.current) {
+      clearTimeout(filterModalCloseTimerRef.current);
+    }
+
+    filterModalCloseTimerRef.current = setTimeout(() => {
+      setIsFilterModalMounted(false);
+      filterModalCloseTimerRef.current = null;
+    }, 220);
+  };
+
+  const handleResetFilter = () => {
+    const allCategories = categoriesByType.ALL;
+    const allCreatorNicknames = (groupInfo?.members ?? []).map(
+      (memberInfo) => memberInfo.nickname,
+    );
+
+    setDraftFilter({
+      type: "ALL",
+      categoryNames: allCategories,
+      creatorNicknames: allCreatorNicknames,
+    });
+  };
+
+  const handleApplyFilter = () => {
+    setAppliedFilter(draftFilter);
+    handleCloseFilterModal();
   };
 
   const openGroupModalWithResolvedLabel = useCallback(async () => {
@@ -666,6 +815,8 @@ export default function GroupTransactionPageClient() {
 
   return (
     <div className="flex flex-col h-screen bg-gray-30 relative font-landing overflow-hidden">
+      <DemoModeTopBanner />
+
       {/* 상단바 */}
       <TransactionHeader
         title={formatDateForDisplay(selectedDate)}
@@ -726,6 +877,7 @@ export default function GroupTransactionPageClient() {
               <TransactionFilter
                 selectedSort={selectedSort}
                 onSortToggle={handleOpenSortModal}
+                onAllToggle={handleOpenFilterModal}
                 stickyTopClass={isSticky ? "top-[106px]" : "top-[102px]"}
               />
 
@@ -797,6 +949,22 @@ export default function GroupTransactionPageClient() {
         selectedSort={selectedSort}
         onClose={handleCloseSortModal}
         onSelect={handleSelectSort}
+      />
+
+      <FilterBottomSheet
+        isMounted={isFilterModalMounted}
+        isOpen={showFilterModal}
+        isGroup
+        categoriesByType={categoriesByType}
+        creators={(groupInfo?.members ?? []).map((memberInfo) => ({
+          nickname: memberInfo.nickname,
+          profileImageUrl: memberInfo.profileImageUrl,
+        }))}
+        draft={draftFilter}
+        onChangeDraft={setDraftFilter}
+        onReset={handleResetFilter}
+        onApply={handleApplyFilter}
+        onClose={handleCloseFilterModal}
       />
 
       {isGroupModalMounted && (
@@ -902,7 +1070,7 @@ export default function GroupTransactionPageClient() {
         </>
       )}
 
-      {!isGroupModalMounted && !isSortModalMounted && (
+      {!isGroupModalMounted && !isSortModalMounted && !isFilterModalMounted && (
         <>
           {isFloatingMenuOpen && (
             <div

--- a/src/components/transaction/my/MyTransactionPageClient.tsx
+++ b/src/components/transaction/my/MyTransactionPageClient.tsx
@@ -11,6 +11,9 @@ import TransactionFilter from "@/components/transaction/v2/TransactionFilter";
 import SortBottomSheet, {
   SortOption,
 } from "@/components/transaction/v2/SortBottomSheet";
+import FilterBottomSheet, {
+  FilterDraftState,
+} from "@/components/transaction/v2/FilterBottomSheet";
 import TransactionTypeToggle, {
   ViewMode,
 } from "@/components/transaction/v2/TransactionTypeToggle";
@@ -24,7 +27,10 @@ import { useMemberStore } from "@/stores/useMemberStore";
 import { useToastStore } from "@/stores/useToastStore";
 import TransactionPageSkeleton from "@/components/skeletons/TransactionPageSkeleton";
 import { getGroups } from "@/services/groupService";
+import { getMyCategories } from "@/services/categoryService";
 import Sidebar from "@/components/ui/Sidebar";
+import DemoModeTopBanner from "@/components/common/DemoModeTopBanner";
+import { isDemoMode } from "@/utils/demoMode";
 
 export default function MyTransactionPageClient() {
   const router = useRouter();
@@ -65,18 +71,47 @@ export default function MyTransactionPageClient() {
   const [selectedSort, setSelectedSort] = useState<SortOption>("최신순");
   const [isSortModalMounted, setIsSortModalMounted] = useState(false);
   const [showSortModal, setShowSortModal] = useState(false);
+  const [isFilterModalMounted, setIsFilterModalMounted] = useState(false);
+  const [showFilterModal, setShowFilterModal] = useState(false);
+  const [appliedFilter, setAppliedFilter] = useState<FilterDraftState>({
+    type: "ALL",
+    categoryNames: [],
+    creatorNicknames: [],
+  });
+  const [draftFilter, setDraftFilter] = useState<FilterDraftState>({
+    type: "ALL",
+    categoryNames: [],
+    creatorNicknames: [],
+  });
+  const [categoriesByType, setCategoriesByType] = useState<{
+    ALL: string[];
+    EXPENSE: string[];
+    INCOME: string[];
+  }>({
+    ALL: [],
+    EXPENSE: [],
+    INCOME: [],
+  });
 
   // 날짜 관련 상태
   const getSavedDate = (): Date => {
     if (typeof window === "undefined") return new Date();
     const saved = sessionStorage.getItem("my-transaction-date");
+    const now = new Date();
     if (saved) {
       const parsed = new Date(saved);
       if (!isNaN(parsed.getTime())) {
+        if (
+          isDemoMode() &&
+          (parsed.getFullYear() !== now.getFullYear() ||
+            parsed.getMonth() !== now.getMonth())
+        ) {
+          return now;
+        }
         return parsed;
       }
     }
-    return new Date();
+    return now;
   };
 
   const [selectedDate, setSelectedDate] = useState<Date>(getSavedDate());
@@ -87,13 +122,6 @@ export default function MyTransactionPageClient() {
     total: 0,
     transactions: [],
   });
-
-  // 필터링 관련 상태
-  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
-  const [allCategories, setAllCategories] = useState<string[]>([]);
-  const [currentCategoryFilter, setCurrentCategoryFilter] = useState<
-    string | null
-  >(null);
 
   // 중복 호출 방지를 위한 ref
   const lastRequestRef = useRef<string>("");
@@ -107,6 +135,9 @@ export default function MyTransactionPageClient() {
 
   const hasFetchedMember = useRef(false);
   const sortModalCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const filterModalCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   useEffect(() => {
     if (!hasFetchedMember.current) {
@@ -120,7 +151,40 @@ export default function MyTransactionPageClient() {
       if (sortModalCloseTimerRef.current) {
         clearTimeout(sortModalCloseTimerRef.current);
       }
+      if (filterModalCloseTimerRef.current) {
+        clearTimeout(filterModalCloseTimerRef.current);
+      }
     };
+  }, []);
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      const [expenseCategories, incomeCategories] = await Promise.all([
+        getMyCategories("EXPENSE"),
+        getMyCategories("INCOME"),
+      ]);
+
+      const expenseNames = expenseCategories.map((category) => category.name);
+      const incomeNames = incomeCategories.map((category) => category.name);
+      const all = Array.from(new Set([...expenseNames, ...incomeNames]));
+
+      setCategoriesByType({
+        ALL: all,
+        EXPENSE: expenseNames,
+        INCOME: incomeNames,
+      });
+
+      const defaultFilter: FilterDraftState = {
+        type: "ALL",
+        categoryNames: all,
+        creatorNicknames: [],
+      };
+
+      setAppliedFilter(defaultFilter);
+      setDraftFilter(defaultFilter);
+    };
+
+    void fetchCategories();
   }, []);
 
   // 사이드바 메뉴 핸들러
@@ -192,7 +256,7 @@ export default function MyTransactionPageClient() {
   useEffect(() => {
     const year = selectedDate.getFullYear();
     const month = selectedDate.getMonth() + 1;
-    const requestKey = `${year}-${month}-${currentCategoryFilter || ""}`;
+    const requestKey = `${year}-${month}`;
 
     if (
       isRequestInProgressRef.current &&
@@ -220,18 +284,10 @@ export default function MyTransactionPageClient() {
             teamId: null,
             year,
             month,
-            categoryName: currentCategoryFilter,
           };
 
           const response = await getTransactions(criteria);
           setResponse(response);
-
-          if (!currentCategoryFilter) {
-            const uniqueCategories = Array.from(
-              new Set(response.transactions.map((t) => t.categoryName)),
-            );
-            setAllCategories(uniqueCategories);
-          }
         } catch (error) {
           if (error instanceof Error && error.message.includes("401")) {
             window.location.href = "/";
@@ -256,14 +312,21 @@ export default function MyTransactionPageClient() {
     return () => {
       clearTimeout(timeoutId);
     };
-  }, [selectedDate, currentCategoryFilter]);
+  }, [selectedDate]);
 
   // 필터링된 거래 내역 가져오기
   const getFilteredTransactions = () => {
     const filtered = response.transactions.filter((transaction) => {
       if (
-        currentCategoryFilter &&
-        transaction.categoryName !== currentCategoryFilter
+        appliedFilter.type !== "ALL" &&
+        transaction.transactionType !== appliedFilter.type
+      ) {
+        return false;
+      }
+
+      if (
+        appliedFilter.categoryNames.length > 0 &&
+        !appliedFilter.categoryNames.includes(transaction.categoryName)
       ) {
         return false;
       }
@@ -329,10 +392,6 @@ export default function MyTransactionPageClient() {
     handleDateChange(newDate);
   };
 
-  const formatNumber = (num: number): string => {
-    return num.toLocaleString("ko-KR");
-  };
-
   // 스크롤 이벤트 핸들러
   const handleScroll = () => {
     if (scrollContainerRef.current) {
@@ -393,13 +452,56 @@ export default function MyTransactionPageClient() {
     handleCloseSortModal();
   };
 
-  // 지출이 더 많은 날인지 확인
-  const isExpenseDay = response.expense > response.income;
-  // 수입이 더 많은 날인지 확인
-  const isIncomeDay = response.income > response.expense;
+  const handleOpenFilterModal = () => {
+    setIsFloatingMenuOpen(false);
+
+    if (filterModalCloseTimerRef.current) {
+      clearTimeout(filterModalCloseTimerRef.current);
+      filterModalCloseTimerRef.current = null;
+    }
+
+    setDraftFilter(appliedFilter);
+
+    if (!isFilterModalMounted) {
+      setIsFilterModalMounted(true);
+      requestAnimationFrame(() => setShowFilterModal(true));
+      return;
+    }
+
+    setShowFilterModal(true);
+  };
+
+  const handleCloseFilterModal = () => {
+    setShowFilterModal(false);
+
+    if (filterModalCloseTimerRef.current) {
+      clearTimeout(filterModalCloseTimerRef.current);
+    }
+
+    filterModalCloseTimerRef.current = setTimeout(() => {
+      setIsFilterModalMounted(false);
+      filterModalCloseTimerRef.current = null;
+    }, 220);
+  };
+
+  const handleResetFilter = () => {
+    const allCategories = categoriesByType.ALL;
+    setDraftFilter({
+      type: "ALL",
+      categoryNames: allCategories,
+      creatorNicknames: [],
+    });
+  };
+
+  const handleApplyFilter = () => {
+    setAppliedFilter(draftFilter);
+    handleCloseFilterModal();
+  };
 
   return (
     <div className="flex flex-col h-screen bg-gray-30 relative font-landing overflow-hidden">
+      <DemoModeTopBanner />
+
       {/* 상단바 (컴포넌트 분리됨) */}
       <TransactionHeader
         title={formatDateForDisplay(selectedDate)}
@@ -444,6 +546,7 @@ export default function MyTransactionPageClient() {
               <TransactionFilter
                 selectedSort={selectedSort}
                 onSortToggle={handleOpenSortModal}
+                onAllToggle={handleOpenFilterModal}
                 stickyTopClass={isSticky ? "top-[106px]" : "top-[102px]"}
               />
 
@@ -506,7 +609,7 @@ export default function MyTransactionPageClient() {
       </div>
 
       {/* 오버레이 (플로팅 메뉴) */}
-      {!isSortModalMounted && isFloatingMenuOpen && (
+      {!isSortModalMounted && !isFilterModalMounted && isFloatingMenuOpen && (
         <div
           className="absolute inset-0 bg-black/20 z-40"
           onClick={() => setIsFloatingMenuOpen(false)}
@@ -521,7 +624,19 @@ export default function MyTransactionPageClient() {
         onSelect={handleSelectSort}
       />
 
-      {!isSortModalMounted && (
+      <FilterBottomSheet
+        isMounted={isFilterModalMounted}
+        isOpen={showFilterModal}
+        isGroup={false}
+        categoriesByType={categoriesByType}
+        draft={draftFilter}
+        onChangeDraft={setDraftFilter}
+        onReset={handleResetFilter}
+        onApply={handleApplyFilter}
+        onClose={handleCloseFilterModal}
+      />
+
+      {!isSortModalMounted && !isFilterModalMounted && (
         <div className="absolute bottom-0 left-0 right-0 pb-6 px-4 flex items-end justify-between pointer-events-none">
           {/* 개인/그룹 토글 */}
           <TransactionTypeToggle

--- a/src/components/transaction/v2/FilterBottomSheet.tsx
+++ b/src/components/transaction/v2/FilterBottomSheet.tsx
@@ -1,0 +1,423 @@
+﻿"use client";
+
+import Image from "next/image";
+import {
+  useMemo,
+  useRef,
+  useState,
+  useEffect,
+  type PointerEvent,
+} from "react";
+
+export type TransactionTypeFilter = "ALL" | "EXPENSE" | "INCOME";
+
+export interface CreatorFilterOption {
+  nickname: string;
+  profileImageUrl?: string | null;
+}
+
+export interface FilterDraftState {
+  type: TransactionTypeFilter;
+  categoryNames: string[];
+  creatorNicknames: string[];
+}
+
+interface FilterBottomSheetProps {
+  isMounted: boolean;
+  isOpen: boolean;
+  isGroup: boolean;
+  categoriesByType: {
+    ALL: string[];
+    EXPENSE: string[];
+    INCOME: string[];
+  };
+  creators?: CreatorFilterOption[];
+  draft: FilterDraftState;
+  onChangeDraft: (next: FilterDraftState) => void;
+  onReset: () => void;
+  onApply: () => void;
+  onClose: () => void;
+}
+
+const MODAL_CLOSE_DRAG_THRESHOLD = 160;
+
+export default function FilterBottomSheet({
+  isMounted,
+  isOpen,
+  isGroup,
+  categoriesByType,
+  creators = [],
+  draft,
+  onChangeDraft,
+  onReset,
+  onApply,
+  onClose,
+}: FilterBottomSheetProps) {
+  const modalDragStartYRef = useRef<number | null>(null);
+  const modalIsDraggingRef = useRef(false);
+  const [modalDragOffset, setModalDragOffset] = useState(0);
+  const [categorySearch, setCategorySearch] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) {
+      setModalDragOffset(0);
+      setCategorySearch("");
+      modalIsDraggingRef.current = false;
+      modalDragStartYRef.current = null;
+    }
+  }, [isOpen]);
+
+  const filteredExpenseCategories = useMemo(() => {
+    const keyword = categorySearch.trim();
+    if (!keyword) return categoriesByType.EXPENSE;
+    return categoriesByType.EXPENSE.filter((name) => name.includes(keyword));
+  }, [categoriesByType.EXPENSE, categorySearch]);
+
+  const filteredIncomeCategories = useMemo(() => {
+    const keyword = categorySearch.trim();
+    if (!keyword) return categoriesByType.INCOME;
+    return categoriesByType.INCOME.filter((name) => name.includes(keyword));
+  }, [categoriesByType.INCOME, categorySearch]);
+
+  const visibleCategories = useMemo(() => {
+    if (draft.type === "EXPENSE") return filteredExpenseCategories;
+    if (draft.type === "INCOME") return filteredIncomeCategories;
+    return Array.from(
+      new Set([...filteredExpenseCategories, ...filteredIncomeCategories]),
+    );
+  }, [draft.type, filteredExpenseCategories, filteredIncomeCategories]);
+
+  const isAllCreatorsSelected =
+    creators.length > 0 &&
+    creators.every((creator) => draft.creatorNicknames.includes(creator.nickname));
+
+  const categoryScope = categoriesByType[draft.type];
+  const isAllCategoriesSelected =
+    categoryScope.length > 0 &&
+    categoryScope.every((category) => draft.categoryNames.includes(category));
+
+  const toggleType = (type: TransactionTypeFilter) => {
+    onChangeDraft({
+      ...draft,
+      type,
+    });
+  };
+
+  const toggleCreator = (nickname: string) => {
+    const isSelected = draft.creatorNicknames.includes(nickname);
+    onChangeDraft({
+      ...draft,
+      creatorNicknames: isSelected
+        ? draft.creatorNicknames.filter((item) => item !== nickname)
+        : [...draft.creatorNicknames, nickname],
+    });
+  };
+
+  const toggleAllCreators = () => {
+    onChangeDraft({
+      ...draft,
+      creatorNicknames: isAllCreatorsSelected
+        ? []
+        : creators.map((creator) => creator.nickname),
+    });
+  };
+
+  const toggleCategory = (name: string) => {
+    const isSelected = draft.categoryNames.includes(name);
+    onChangeDraft({
+      ...draft,
+      categoryNames: isSelected
+        ? draft.categoryNames.filter((item) => item !== name)
+        : [...draft.categoryNames, name],
+    });
+  };
+
+  const toggleAllCategories = () => {
+    if (isAllCategoriesSelected) {
+      onChangeDraft({
+        ...draft,
+        categoryNames: draft.categoryNames.filter(
+          (name) => !categoryScope.includes(name),
+        ),
+      });
+      return;
+    }
+
+    const merged = new Set([...draft.categoryNames, ...categoryScope]);
+    onChangeDraft({
+      ...draft,
+      categoryNames: Array.from(merged),
+    });
+  };
+
+  const handleModalHandlePointerDown = (e: PointerEvent<HTMLDivElement>) => {
+    modalIsDraggingRef.current = true;
+    modalDragStartYRef.current = e.clientY;
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+
+  const handleModalHandlePointerMove = (e: PointerEvent<HTMLDivElement>) => {
+    if (!modalIsDraggingRef.current || modalDragStartYRef.current === null) {
+      return;
+    }
+
+    const deltaY = Math.max(0, e.clientY - modalDragStartYRef.current);
+    setModalDragOffset(deltaY);
+  };
+
+  const handleModalHandlePointerUp = (e: PointerEvent<HTMLDivElement>) => {
+    if (!modalIsDraggingRef.current) return;
+
+    modalIsDraggingRef.current = false;
+    modalDragStartYRef.current = null;
+    e.currentTarget.releasePointerCapture(e.pointerId);
+
+    if (modalDragOffset > MODAL_CLOSE_DRAG_THRESHOLD) {
+      onClose();
+      return;
+    }
+
+    setModalDragOffset(0);
+  };
+
+  if (!isMounted) return null;
+
+  return (
+    <>
+      <div
+        className={`absolute inset-0 z-40 transition-opacity duration-200 ${
+          isOpen ? "bg-[#d9d9d9] opacity-50" : "bg-[#d9d9d9] opacity-0"
+        }`}
+        onClick={onClose}
+      />
+
+      <div
+        className={`absolute left-0 right-0 bottom-0 z-50 bg-gray-30 rounded-t-[20px] rounded-b-none pt-3 pb-0 ${
+          modalIsDraggingRef.current
+            ? ""
+            : "transition-transform duration-200 ease-out"
+        }`}
+        style={{
+          transform: isOpen
+            ? `translateY(${modalDragOffset}px)`
+            : "translateY(100%)",
+        }}
+      >
+        <div
+          className="w-16 h-[5px] bg-gray-100 rounded-[100px] mx-auto mb-5 cursor-grab active:cursor-grabbing touch-none"
+          onPointerDown={handleModalHandlePointerDown}
+          onPointerMove={handleModalHandlePointerMove}
+          onPointerUp={handleModalHandlePointerUp}
+          onPointerCancel={handleModalHandlePointerUp}
+        />
+
+        <p className="px-4 text-subtitle text-gray-900 mb-4">필터</p>
+        <div className="border-t border-gray-100" />
+
+        <div className="max-h-[720px] flex flex-col">
+          <div className="overflow-y-auto px-4 pt-4 pb-4 flex-1 min-h-0">
+            <div className="flex items-center gap-2 mb-4">
+              {[
+                { key: "ALL", label: "전체" },
+                { key: "EXPENSE", label: "지출만" },
+                { key: "INCOME", label: "수입만" },
+              ].map((type) => {
+                const isSelected = draft.type === type.key;
+                return (
+                  <button
+                    key={type.key}
+                    onClick={() => toggleType(type.key as TransactionTypeFilter)}
+                    className={`h-8 px-4 rounded-[100px] border cursor-pointer ${
+                      isSelected
+                        ? "border-gray-900 bg-white text-gray-900 text-body2-semibold"
+                        : "border-gray-100 bg-gray-50 text-gray-500 text-body2-regular"
+                    }`}
+                  >
+                    {type.label}
+                  </button>
+                );
+              })}
+            </div>
+
+            {isGroup && creators.length > 0 && (
+              <>
+                <div className="flex items-center justify-between mb-3">
+                  <p className="text-body1-semibold text-gray-900">작성자</p>
+                  <button
+                    onClick={toggleAllCreators}
+                    className="flex items-center gap-2 cursor-pointer"
+                  >
+                    <span
+                      className={`w-[18px] h-[18px] rounded-[6px] flex items-center justify-center text-[12px] leading-none ${
+                        isAllCreatorsSelected
+                          ? "bg-gray-900 text-white"
+                          : "border border-gray-200 text-transparent"
+                      }`}
+                    >
+                      ✓
+                    </span>
+                    <span className="text-body2-regular text-gray-700">전체선택</span>
+                  </button>
+                </div>
+
+                <div className="flex flex-wrap gap-2 mb-6">
+                  {creators.map((creator) => {
+                    const isSelected = draft.creatorNicknames.includes(
+                      creator.nickname,
+                    );
+                    return (
+                      <button
+                        key={creator.nickname}
+                        onClick={() => toggleCreator(creator.nickname)}
+                        className={`h-11 pl-1 pr-4 rounded-[100px] border flex items-center gap-2 cursor-pointer ${
+                          isSelected
+                            ? "border-gray-900 bg-white"
+                            : "border-gray-300 bg-white"
+                        }`}
+                      >
+                        <div className="w-8 h-8 rounded-full bg-gray-100 overflow-hidden flex items-center justify-center">
+                          {creator.profileImageUrl ? (
+                            <Image
+                              src={creator.profileImageUrl}
+                              alt={creator.nickname}
+                              width={32}
+                              height={32}
+                              className="h-8 w-8 rounded-full object-cover"
+                              unoptimized
+                            />
+                          ) : (
+                            <span className="text-caption1 text-gray-500">
+                              {creator.nickname.slice(0, 1)}
+                            </span>
+                          )}
+                        </div>
+                        <span className="text-body2-regular text-gray-900">
+                          {creator.nickname}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </>
+            )}
+
+            <div className="flex items-center justify-between mb-3">
+              <p className="text-body1-semibold text-gray-900">카테고리</p>
+              <button
+                onClick={toggleAllCategories}
+                className="flex items-center gap-2 cursor-pointer"
+              >
+                <span
+                  className={`w-[18px] h-[18px] rounded-[6px] flex items-center justify-center text-[12px] leading-none ${
+                    isAllCategoriesSelected
+                      ? "bg-gray-900 text-white"
+                      : "border border-gray-200 text-transparent"
+                  }`}
+                >
+                  ✓
+                </span>
+                <span className="text-body2-regular text-gray-700">전체선택</span>
+              </button>
+            </div>
+
+            <div className="h-11 rounded-[12px] bg-gray-50 border border-gray-100 px-4 flex items-center gap-2 mb-4">
+              <Image
+                src="/images/transaction/v2/돋보기_회색.svg"
+                alt="검색"
+                width={20}
+                height={20}
+              />
+              <input
+                value={categorySearch}
+                onChange={(e) => setCategorySearch(e.target.value)}
+                placeholder="카테고리 검색"
+                className="w-full bg-transparent outline-none text-body2-regular text-gray-900 placeholder:text-gray-300"
+              />
+            </div>
+
+            {draft.type === "ALL" ? (
+              <>
+                <div className="flex flex-wrap gap-2">
+                  {filteredExpenseCategories.map((name) => {
+                    const isSelected = draft.categoryNames.includes(name);
+                    return (
+                      <button
+                        key={`expense-${name}`}
+                        onClick={() => toggleCategory(name)}
+                        className={`h-10 px-4 rounded-[100px] border cursor-pointer ${
+                          isSelected
+                            ? "border-gray-900 bg-white text-gray-900 text-body2-semibold"
+                            : "border-gray-300 bg-white text-gray-800 text-body2-regular"
+                        }`}
+                      >
+                        {name}
+                      </button>
+                    );
+                  })}
+                </div>
+
+                {filteredExpenseCategories.length > 0 &&
+                  filteredIncomeCategories.length > 0 && (
+                    <div className="border-t border-gray-100 my-4" />
+                  )}
+
+                <div className="flex flex-wrap gap-2">
+                  {filteredIncomeCategories.map((name) => {
+                    const isSelected = draft.categoryNames.includes(name);
+                    return (
+                      <button
+                        key={`income-${name}`}
+                        onClick={() => toggleCategory(name)}
+                        className={`h-10 px-4 rounded-[100px] border cursor-pointer ${
+                          isSelected
+                            ? "border-gray-900 bg-white text-gray-900 text-body2-semibold"
+                            : "border-gray-300 bg-white text-gray-800 text-body2-regular"
+                        }`}
+                      >
+                        {name}
+                      </button>
+                    );
+                  })}
+                </div>
+              </>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {visibleCategories.map((name) => {
+                  const isSelected = draft.categoryNames.includes(name);
+                  return (
+                    <button
+                      key={name}
+                      onClick={() => toggleCategory(name)}
+                      className={`h-10 px-4 rounded-[100px] border cursor-pointer ${
+                        isSelected
+                          ? "border-gray-900 bg-white text-gray-900 text-body2-semibold"
+                          : "border-gray-300 bg-white text-gray-800 text-body2-regular"
+                      }`}
+                    >
+                      {name}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          <div className="border-t border-gray-100 px-3 py-3 flex gap-2 bg-gray-30">
+            <button
+              onClick={onReset}
+              className="flex-1 h-[52px] rounded-[12px] border border-gray-300 bg-white text-subtitle text-gray-900 cursor-pointer"
+            >
+              초기화
+            </button>
+            <button
+              onClick={onApply}
+              className="flex-[1.6] h-[52px] rounded-[12px] bg-gray-900 text-subtitle text-white cursor-pointer"
+            >
+              선택 완료
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/transaction/v2/TransactionHeader.tsx
+++ b/src/components/transaction/v2/TransactionHeader.tsx
@@ -24,7 +24,7 @@ export default function TransactionHeader({
       <button onClick={onPrevMonth} className="cursor-pointer">
         <Image
           src="/images/transaction/v2/좌측_화살표_회색.svg"
-          alt="이전 달"
+          alt="이전 월"
           width={10}
           height={16}
         />
@@ -35,16 +35,13 @@ export default function TransactionHeader({
       <button onClick={onNextMonth} className="cursor-pointer">
         <Image
           src="/images/transaction/v2/우측_화살표_회색.svg"
-          alt="다음 달"
+          alt="다음 월"
           width={10}
           height={16}
         />
       </button>
 
-      <button
-        onClick={onMenuClick}
-        className="absolute right-6 cursor-pointer"
-      >
+      <button onClick={onMenuClick} className="absolute right-6 cursor-pointer">
         <Image
           src="/images/transaction/v2/햄버거_메뉴.svg"
           alt="메뉴"

--- a/src/components/ui/Sidebar.tsx
+++ b/src/components/ui/Sidebar.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useToastStore } from "@/stores/useToastStore";
+import { isDemoMode } from "@/utils/demoMode";
 
 interface SidebarProps {
   isOpen: boolean;
@@ -13,8 +14,8 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
   const router = useRouter();
   const addToast = useToastStore((state) => state.addToast);
   const sidebarRef = useRef<HTMLDivElement>(null);
+  const isGuest = isDemoMode();
 
-  // 외부 클릭 감지
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (
@@ -34,8 +35,13 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
     };
   }, [isOpen, onClose]);
 
-  // 메뉴 항목 클릭 핸들러들
   const handleMyPage = () => {
+    if (isGuest) {
+      onClose();
+      router.push("/?panel=login");
+      return;
+    }
+
     onClose();
     router.push("/profile");
   };
@@ -55,13 +61,11 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
 
   return (
     <>
-      {/* 반투명 오버레이 */}
       <div
         className="absolute inset-0 bg-[#d9d9d9] opacity-50 z-60"
         onClick={onClose}
       />
 
-      {/* 사이드바 본문 */}
       <div
         ref={sidebarRef}
         className="absolute top-0 right-0 h-full w-48 bg-white shadow-lg border-l border-[#E0E0E0] transform transition-transform duration-300 ease-in-out z-70"
@@ -73,7 +77,9 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
               onClick={handleMyPage}
               className="w-full text-left p-3 hover:bg-gray-100 rounded-lg cursor-pointer transition-colors"
             >
-              <span className="text-subtitle text-gray-900">마이페이지</span>
+              <span className="text-subtitle text-gray-900">
+                {isGuest ? "로그인" : "마이페이지"}
+              </span>
             </button>
             <button
               onClick={handleNotice}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,7 +6,6 @@ export function proxy(request: NextRequest) {
   const refreshToken = request.cookies.get("refreshToken")?.value;
   const path = request.nextUrl.pathname;
 
-  // 정적 자원 제외
   if (
     path.includes("/_next") ||
     path.includes("/api") ||
@@ -17,13 +16,12 @@ export function proxy(request: NextRequest) {
 
   const publicPaths = ["/"];
   const authOptionalPaths = ["/sign-up"];
-  const protectedPaths = ["/transaction", "/group", "/profile"];
+  const protectedPaths = ["/profile"];
 
   const isPublicPath = publicPaths.some((p) => path === p);
   const isAuthOptionalPath = authOptionalPaths.some((p) => path.startsWith(p));
   const isProtectedPath = protectedPaths.some((p) => path.startsWith(p));
 
-  // 🔥 보호된 경로 접근 시 리프레시 토큰만 확인
   if (isProtectedPath) {
     if (!refreshToken) {
       return NextResponse.redirect(new URL("/", request.url));
@@ -31,16 +29,11 @@ export function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // 🔥 회원가입 페이지: 액세스 토큰이 있을 때만 리다이렉트
   if (isAuthOptionalPath && accessToken) {
     return NextResponse.redirect(new URL("/transaction/my", request.url));
   }
 
-  // 🔥 메인 페이지(로그인 페이지): 로그인 상태면 거래 내역으로 리다이렉트
   if (isPublicPath) {
-    if (refreshToken && !request.nextUrl.search) {
-      return NextResponse.redirect(new URL("/transaction/my", request.url));
-    }
     return NextResponse.next();
   }
 

--- a/src/services/categoryService.ts
+++ b/src/services/categoryService.ts
@@ -1,6 +1,8 @@
 // services/categoryService.ts
-import { get, post, put, del } from "@/utils/apiClient";
+import { get } from "@/utils/apiClient";
 import { useToastStore } from "@/stores/useToastStore";
+import { isDemoMode } from "@/utils/demoMode";
+import { getDemoCategories } from "@/services/demoData";
 
 // 🔥 중복 요청 방지를 위한 Promise 캐시
 const pendingCategoryRequests = new Map<string, Promise<Category[]>>();
@@ -22,6 +24,15 @@ export interface GetCategoriesResponse {
 export const getMyCategories = async (
   transactionType: "INCOME" | "EXPENSE"
 ): Promise<Category[]> => {
+  if (isDemoMode()) {
+    return getDemoCategories(null, transactionType).map((category) => ({
+      id: category.id,
+      name: category.name,
+      iconUrl: category.iconUrl,
+      ownerType: category.ownerType,
+    }));
+  }
+
   const url = `/api/categories?transactionType=${transactionType}`;
 
   // 🔥 이미 동일한 요청이 진행 중이면 기존 Promise 반환
@@ -54,6 +65,15 @@ export const getTeamCategories = async (
   teamId: number,
   transactionType: "INCOME" | "EXPENSE"
 ): Promise<Category[]> => {
+  if (isDemoMode()) {
+    return getDemoCategories(teamId, transactionType).map((category) => ({
+      id: category.id,
+      name: category.name,
+      iconUrl: category.iconUrl,
+      ownerType: category.ownerType,
+    }));
+  }
+
   const url = `/api/categories?teamId=${teamId}&transactionType=${transactionType}`;
 
   // 🔥 이미 동일한 요청이 진행 중이면 기존 Promise 반환

--- a/src/services/demoData.ts
+++ b/src/services/demoData.ts
@@ -1,0 +1,615 @@
+type TransactionType = "INCOME" | "EXPENSE";
+
+interface DemoMember {
+  memberId: string;
+  nickname: string;
+  profileImageUrl: string;
+}
+
+export interface DemoCategory {
+  id: number;
+  name: string;
+  iconUrl: string;
+  ownerType: "USER" | "SYSTEM";
+  transactionType: TransactionType;
+  teamId: number | null;
+}
+
+export interface DemoTransaction {
+  transactionId: string;
+  teamId: number | null;
+  amount: number;
+  content: string;
+  transactionDate: string;
+  transactionType: TransactionType;
+  creatorNickname: string;
+  creatorProfileImageUrl?: string | null;
+  categoryId: number;
+  categoryName: string;
+  iconUrl: string;
+}
+
+interface DemoGroup {
+  teamId: string;
+  title: string;
+  label: string;
+  purpose: string;
+  memberLimit: number;
+  invitationCode: string;
+  leaderNickname: string;
+  members: DemoMember[];
+}
+
+const defaultAvatars = [
+  process.env.NEXT_PUBLIC_DEFAULT_AVATAR_1 || "",
+  process.env.NEXT_PUBLIC_DEFAULT_AVATAR_2 || "",
+  process.env.NEXT_PUBLIC_DEFAULT_AVATAR_3 || "",
+  process.env.NEXT_PUBLIC_DEFAULT_AVATAR_4 || "",
+];
+
+const avatarByIndex = (index: number) => defaultAvatars[index] ?? defaultAvatars[0] ?? "";
+
+const demoSelfMember: DemoMember = {
+  memberId: "demo-member-1",
+  nickname: "체험유저1",
+  profileImageUrl: avatarByIndex(0),
+};
+
+const demoMembers: DemoMember[] = [
+  demoSelfMember,
+  { memberId: "demo-member-2", nickname: "체험유저2", profileImageUrl: avatarByIndex(1) },
+  { memberId: "demo-member-3", nickname: "체험유저3", profileImageUrl: avatarByIndex(2) },
+  { memberId: "demo-member-4", nickname: "체험유저4", profileImageUrl: avatarByIndex(3) },
+];
+
+const createIsoDate = (monthOffset: number, day: number, hour: number) => {
+  const now = new Date();
+  const target = new Date(now.getFullYear(), now.getMonth() + monthOffset, day, hour, 0, 0);
+  return target.toISOString();
+};
+
+const nextInviteCode = () => {
+  let code = "";
+  while (code.length < 8) {
+    code += Math.random()
+      .toString(36)
+      .toUpperCase()
+      .replace(/[^A-Z0-9]/g, "");
+  }
+  return code.slice(0, 8);
+};
+
+const CATEGORY_ICON = "/images/transaction/v2/리스트_카테고리.svg";
+
+let categorySeedId = 0;
+let transactionSeedId = 0;
+let groupSeedId = 0;
+
+const demoCategories: DemoCategory[] = [
+  { id: 1, name: "식비", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "EXPENSE", teamId: null },
+  { id: 2, name: "카페", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "EXPENSE", teamId: null },
+  { id: 3, name: "교통", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "EXPENSE", teamId: null },
+  { id: 4, name: "쇼핑", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "EXPENSE", teamId: null },
+  { id: 5, name: "급여", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "INCOME", teamId: null },
+  { id: 6, name: "용돈", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "INCOME", teamId: null },
+  { id: 7, name: "사업수입", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "INCOME", teamId: null },
+
+  { id: 101, name: "식비", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "EXPENSE", teamId: 1 },
+  { id: 102, name: "생활용품", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "EXPENSE", teamId: 1 },
+  { id: 103, name: "교통", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "EXPENSE", teamId: 1 },
+  { id: 104, name: "공동정산", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "INCOME", teamId: 1 },
+  { id: 105, name: "용돈", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "INCOME", teamId: 1 },
+
+  { id: 201, name: "식비", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "EXPENSE", teamId: 2 },
+  { id: 202, name: "주거", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "EXPENSE", teamId: 2 },
+  { id: 203, name: "간식", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "EXPENSE", teamId: 2 },
+  { id: 204, name: "공동정산", iconUrl: CATEGORY_ICON, ownerType: "SYSTEM", transactionType: "INCOME", teamId: 2 },
+];
+
+const demoGroups: DemoGroup[] = [
+  {
+    teamId: "1",
+    title: "체험 그룹 A",
+    label: "green",
+    purpose: "생활비 같이 관리",
+    memberLimit: 10,
+    invitationCode: "DEMO2026",
+    leaderNickname: "체험유저1",
+    members: [...demoMembers],
+  },
+  {
+    teamId: "2",
+    title: "체험 그룹 B",
+    label: "orange",
+    purpose: "모임비 정산",
+    memberLimit: 8,
+    invitationCode: "DEMO2027",
+    leaderNickname: "체험유저2",
+    members: [...demoMembers],
+  },
+];
+
+let demoTransactions: DemoTransaction[] = [
+  {
+    transactionId: "3001",
+    teamId: null,
+    amount: 8500,
+    content: "점심 식사",
+    transactionDate: createIsoDate(0, 2, 12),
+    transactionType: "EXPENSE",
+    creatorNickname: "체험유저1",
+    creatorProfileImageUrl: avatarByIndex(0),
+    categoryId: 1,
+    categoryName: "식비",
+    iconUrl: CATEGORY_ICON,
+  },
+  {
+    transactionId: "3002",
+    teamId: null,
+    amount: 5200,
+    content: "아이스라떼",
+    transactionDate: createIsoDate(0, 3, 9),
+    transactionType: "EXPENSE",
+    creatorNickname: "체험유저1",
+    creatorProfileImageUrl: avatarByIndex(0),
+    categoryId: 2,
+    categoryName: "카페",
+    iconUrl: CATEGORY_ICON,
+  },
+  {
+    transactionId: "3003",
+    teamId: null,
+    amount: 132000,
+    content: "온라인 쇼핑",
+    transactionDate: createIsoDate(0, 5, 20),
+    transactionType: "EXPENSE",
+    creatorNickname: "체험유저1",
+    creatorProfileImageUrl: avatarByIndex(0),
+    categoryId: 4,
+    categoryName: "쇼핑",
+    iconUrl: CATEGORY_ICON,
+  },
+  {
+    transactionId: "3004",
+    teamId: null,
+    amount: 3200000,
+    content: "월급",
+    transactionDate: createIsoDate(-1, 1, 9),
+    transactionType: "INCOME",
+    creatorNickname: "체험유저1",
+    creatorProfileImageUrl: avatarByIndex(0),
+    categoryId: 5,
+    categoryName: "급여",
+    iconUrl: CATEGORY_ICON,
+  },
+  {
+    transactionId: "3005",
+    teamId: null,
+    amount: 50000,
+    content: "부모님 용돈",
+    transactionDate: createIsoDate(-2, 7, 19),
+    transactionType: "INCOME",
+    creatorNickname: "체험유저1",
+    creatorProfileImageUrl: avatarByIndex(0),
+    categoryId: 6,
+    categoryName: "용돈",
+    iconUrl: CATEGORY_ICON,
+  },
+  {
+    transactionId: "3006",
+    teamId: null,
+    amount: 14500,
+    content: "지하철 정기권",
+    transactionDate: createIsoDate(-1, 9, 8),
+    transactionType: "EXPENSE",
+    creatorNickname: "체험유저1",
+    creatorProfileImageUrl: avatarByIndex(0),
+    categoryId: 3,
+    categoryName: "교통",
+    iconUrl: CATEGORY_ICON,
+  },
+  {
+    transactionId: "3007",
+    teamId: null,
+    amount: 9100,
+    content: "저녁 식사",
+    transactionDate: createIsoDate(0, 11, 18),
+    transactionType: "EXPENSE",
+    creatorNickname: "체험유저1",
+    creatorProfileImageUrl: avatarByIndex(0),
+    categoryId: 1,
+    categoryName: "식비",
+    iconUrl: CATEGORY_ICON,
+  },
+  {
+    transactionId: "3008",
+    teamId: null,
+    amount: 280000,
+    content: "사이드 프로젝트 정산",
+    transactionDate: createIsoDate(-2, 13, 14),
+    transactionType: "INCOME",
+    creatorNickname: "체험유저1",
+    creatorProfileImageUrl: avatarByIndex(0),
+    categoryId: 7,
+    categoryName: "사업수입",
+    iconUrl: CATEGORY_ICON,
+  },
+
+  {
+    transactionId: "3101",
+    teamId: 1,
+    amount: 26000,
+    content: "마트 장보기",
+    transactionDate: createIsoDate(0, 2, 18),
+    transactionType: "EXPENSE",
+    creatorNickname: "체험유저2",
+    creatorProfileImageUrl: avatarByIndex(1),
+    categoryId: 102,
+    categoryName: "생활용품",
+    iconUrl: CATEGORY_ICON,
+  },
+  {
+    transactionId: "3102",
+    teamId: 1,
+    amount: 12000,
+    content: "점심 회비",
+    transactionDate: createIsoDate(-1, 3, 13),
+    transactionType: "EXPENSE",
+    creatorNickname: "체험유저3",
+    creatorProfileImageUrl: avatarByIndex(2),
+    categoryId: 101,
+    categoryName: "식비",
+    iconUrl: CATEGORY_ICON,
+  },
+  {
+    transactionId: "3103",
+    teamId: 1,
+    amount: 18000,
+    content: "택시비",
+    transactionDate: createIsoDate(0, 5, 23),
+    transactionType: "EXPENSE",
+    creatorNickname: "체험유저4",
+    creatorProfileImageUrl: avatarByIndex(3),
+    categoryId: 103,
+    categoryName: "교통",
+    iconUrl: CATEGORY_ICON,
+  },
+  {
+    transactionId: "3104",
+    teamId: 1,
+    amount: 70000,
+    content: "공동 정산 입금",
+    transactionDate: createIsoDate(-2, 6, 10),
+    transactionType: "INCOME",
+    creatorNickname: "체험유저1",
+    creatorProfileImageUrl: avatarByIndex(0),
+    categoryId: 104,
+    categoryName: "공동정산",
+    iconUrl: CATEGORY_ICON,
+  },
+  {
+    transactionId: "3105",
+    teamId: 1,
+    amount: 33000,
+    content: "주말 외식",
+    transactionDate: createIsoDate(-1, 9, 20),
+    transactionType: "EXPENSE",
+    creatorNickname: "체험유저2",
+    creatorProfileImageUrl: avatarByIndex(1),
+    categoryId: 101,
+    categoryName: "식비",
+    iconUrl: CATEGORY_ICON,
+  },
+
+  {
+    transactionId: "3201",
+    teamId: 2,
+    amount: 21000,
+    content: "모임 간식",
+    transactionDate: createIsoDate(0, 4, 16),
+    transactionType: "EXPENSE",
+    creatorNickname: "체험유저3",
+    creatorProfileImageUrl: avatarByIndex(2),
+    categoryId: 203,
+    categoryName: "간식",
+    iconUrl: CATEGORY_ICON,
+  },
+  {
+    transactionId: "3202",
+    teamId: 2,
+    amount: 150000,
+    content: "회비 입금",
+    transactionDate: createIsoDate(-1, 8, 11),
+    transactionType: "INCOME",
+    creatorNickname: "체험유저2",
+    creatorProfileImageUrl: avatarByIndex(1),
+    categoryId: 204,
+    categoryName: "공동정산",
+    iconUrl: CATEGORY_ICON,
+  },
+  {
+    transactionId: "3203",
+    teamId: 2,
+    amount: 92000,
+    content: "공간 대여비",
+    transactionDate: createIsoDate(-2, 10, 15),
+    transactionType: "EXPENSE",
+    creatorNickname: "체험유저4",
+    creatorProfileImageUrl: avatarByIndex(3),
+    categoryId: 202,
+    categoryName: "주거",
+    iconUrl: CATEGORY_ICON,
+  },
+];
+
+categorySeedId = demoCategories.reduce((maxId, category) => {
+  return category.id > maxId ? category.id : maxId;
+}, categorySeedId);
+
+transactionSeedId = demoTransactions.reduce((maxId, transaction) => {
+  const currentId = Number(transaction.transactionId);
+  return currentId > maxId ? currentId : maxId;
+}, transactionSeedId);
+
+groupSeedId = demoGroups.reduce((maxId, group) => {
+  const currentId = Number(group.teamId);
+  return currentId > maxId ? currentId : maxId;
+}, groupSeedId);
+
+const findCategoryById = (categoryId: number) =>
+  demoCategories.find((category) => category.id === categoryId);
+
+export const getDemoSelfMember = () => demoSelfMember;
+
+export const getDemoGroups = () => demoGroups;
+
+export const getDemoGroupInfo = (teamId: string) =>
+  demoGroups.find((group) => group.teamId === teamId) ?? null;
+
+export const createDemoGroup = (payload: {
+  title: string;
+  memberLimit: number;
+  purpose: string | null;
+  label: string;
+}) => {
+  groupSeedId += 1;
+  const teamId = String(groupSeedId);
+  const invitationCode = nextInviteCode();
+
+  demoGroups.unshift({
+    teamId,
+    title: payload.title,
+    label: payload.label,
+    purpose: payload.purpose ?? "",
+    memberLimit: payload.memberLimit,
+    invitationCode,
+    leaderNickname: demoSelfMember.nickname,
+    members: [demoSelfMember],
+  });
+
+  const defaultExpenseCategories = ["식비", "생활용품", "교통"];
+  const defaultIncomeCategories = ["공동정산", "용돈"];
+
+  defaultExpenseCategories.forEach((name) => {
+    categorySeedId += 1;
+    demoCategories.push({
+      id: categorySeedId,
+      name,
+      iconUrl: CATEGORY_ICON,
+      ownerType: "SYSTEM",
+      transactionType: "EXPENSE",
+      teamId: Number(teamId),
+    });
+  });
+
+  defaultIncomeCategories.forEach((name) => {
+    categorySeedId += 1;
+    demoCategories.push({
+      id: categorySeedId,
+      name,
+      iconUrl: CATEGORY_ICON,
+      ownerType: "SYSTEM",
+      transactionType: "INCOME",
+      teamId: Number(teamId),
+    });
+  });
+
+  return invitationCode;
+};
+
+export const updateDemoGroup = (payload: {
+  teamId: string;
+  title: string;
+  memberLimit: number;
+  purpose: string | null;
+  label: string;
+}) => {
+  const target = demoGroups.find((group) => group.teamId === payload.teamId);
+  if (!target) return;
+
+  target.title = payload.title;
+  target.memberLimit = payload.memberLimit;
+  target.purpose = payload.purpose ?? "";
+  target.label = payload.label;
+};
+
+export const joinDemoGroup = (invitationCode: string) => {
+  const target = demoGroups.find(
+    (group) => group.invitationCode.toUpperCase() === invitationCode.toUpperCase(),
+  );
+  if (!target) {
+    throw new Error("초대코드를 찾을 수 없어요.");
+  }
+
+  if (!target.members.some((member) => member.nickname === demoSelfMember.nickname)) {
+    target.members.push(demoSelfMember);
+  }
+
+  return { teamId: target.teamId, title: target.title };
+};
+
+export const leaveDemoGroup = (teamId: string, nextLeaderNickname?: string) => {
+  const target = demoGroups.find((group) => group.teamId === teamId);
+  if (!target) return;
+
+  const isLeader = target.leaderNickname === demoSelfMember.nickname;
+  if (isLeader && nextLeaderNickname) {
+    target.leaderNickname = nextLeaderNickname;
+  }
+
+  target.members = target.members.filter(
+    (member) => member.nickname !== demoSelfMember.nickname,
+  );
+
+  if (target.members.length === 0) {
+    const index = demoGroups.findIndex((group) => group.teamId === teamId);
+    if (index >= 0) demoGroups.splice(index, 1);
+    demoTransactions = demoTransactions.filter(
+      (transaction) => String(transaction.teamId) !== teamId,
+    );
+    for (let i = demoCategories.length - 1; i >= 0; i -= 1) {
+      if (String(demoCategories[i].teamId ?? "") === teamId) {
+        demoCategories.splice(i, 1);
+      }
+    }
+  }
+};
+
+export const updateDemoGroupOrder = (
+  orders: Array<{ teamId: string; displayOrder: number }>,
+) => {
+  const orderMap = new Map(orders.map((order) => [order.teamId, order.displayOrder]));
+  demoGroups.sort((a, b) => (orderMap.get(a.teamId) ?? 0) - (orderMap.get(b.teamId) ?? 0));
+};
+
+export const getDemoCategories = (
+  teamId: number | null,
+  transactionType: TransactionType,
+) =>
+  demoCategories.filter(
+    (category) =>
+      category.teamId === teamId && category.transactionType === transactionType,
+  );
+
+export const addDemoTransaction = (payload: {
+  categoryId: number;
+  teamId?: number | null;
+  amount: number;
+  content: string | null;
+  transactionDate: string;
+  transactionType: TransactionType;
+}) => {
+  transactionSeedId += 1;
+  const category = findCategoryById(payload.categoryId);
+
+  demoTransactions.unshift({
+    transactionId: String(transactionSeedId),
+    teamId: payload.teamId ?? null,
+    amount: payload.amount,
+    content: payload.content ?? "",
+    transactionDate: payload.transactionDate,
+    transactionType: payload.transactionType,
+    creatorNickname: demoSelfMember.nickname,
+    creatorProfileImageUrl: demoSelfMember.profileImageUrl,
+    categoryId: payload.categoryId,
+    categoryName: category?.name ?? "기타",
+    iconUrl: category?.iconUrl ?? CATEGORY_ICON,
+  });
+};
+
+export const getDemoTransactionsByMonth = (criteria: {
+  teamId?: number | null;
+  year: number;
+  month: number;
+  categoryName?: string | null;
+  creatorNickname?: string | null;
+}) => {
+  const items = demoTransactions.filter((transaction) => {
+    const date = new Date(transaction.transactionDate);
+    const sameTeam =
+      criteria.teamId === null || criteria.teamId === undefined
+        ? transaction.teamId === null
+        : transaction.teamId === criteria.teamId;
+    const sameYear = date.getFullYear() === criteria.year;
+    const sameMonth = date.getMonth() + 1 === criteria.month;
+    const sameCategory =
+      !criteria.categoryName || transaction.categoryName === criteria.categoryName;
+    const sameCreator =
+      !criteria.creatorNickname ||
+      transaction.creatorNickname === criteria.creatorNickname;
+
+    return sameTeam && sameYear && sameMonth && sameCategory && sameCreator;
+  });
+
+  const income = items
+    .filter((item) => item.transactionType === "INCOME")
+    .reduce((acc, cur) => acc + cur.amount, 0);
+  const expense = items
+    .filter((item) => item.transactionType === "EXPENSE")
+    .reduce((acc, cur) => acc + cur.amount, 0);
+
+  return {
+    income,
+    expense,
+    total: income - expense,
+    transactions: items,
+  };
+};
+
+export const getDemoTransactionById = (transactionId: string, teamId?: string) => {
+  const found = demoTransactions.find((item) => item.transactionId === transactionId);
+  if (!found) return null;
+  if (typeof teamId !== "undefined" && String(found.teamId ?? "") !== teamId) {
+    return null;
+  }
+  return found;
+};
+
+export const updateDemoTransaction = (
+  transactionId: string,
+  payload: {
+    categoryId: number;
+    teamId?: number | null;
+    amount: number;
+    content: string | null;
+    transactionDate: string;
+    transactionType: TransactionType;
+  },
+) => {
+  const target = demoTransactions.find((item) => item.transactionId === transactionId);
+  if (!target) return;
+
+  const category = findCategoryById(payload.categoryId);
+  target.categoryId = payload.categoryId;
+  target.teamId = payload.teamId ?? target.teamId;
+  target.amount = payload.amount;
+  target.content = payload.content ?? "";
+  target.transactionDate = payload.transactionDate;
+  target.transactionType = payload.transactionType;
+  target.categoryName = category?.name ?? target.categoryName;
+  target.iconUrl = category?.iconUrl ?? target.iconUrl;
+};
+
+export const deleteDemoTransaction = (transactionId: string) => {
+  demoTransactions = demoTransactions.filter(
+    (item) => item.transactionId !== transactionId,
+  );
+};
+
+export const addDemoCategory = (
+  teamId: number | null,
+  transactionType: TransactionType,
+  name: string,
+) => {
+  categorySeedId += 1;
+  const next: DemoCategory = {
+    id: categorySeedId,
+    name,
+    iconUrl: CATEGORY_ICON,
+    ownerType: "USER",
+    transactionType,
+    teamId,
+  };
+  demoCategories.push(next);
+  return next;
+};

--- a/src/services/groupService.ts
+++ b/src/services/groupService.ts
@@ -1,6 +1,17 @@
 ﻿// services/groupService.ts
 import { get, post, del, patch } from "@/utils/apiClient";
 import { useToastStore } from "@/stores/useToastStore";
+import { isDemoMode } from "@/utils/demoMode";
+import {
+  createDemoGroup,
+  getDemoSelfMember,
+  getDemoGroupInfo,
+  getDemoGroups,
+  joinDemoGroup,
+  leaveDemoGroup,
+  updateDemoGroup,
+  updateDemoGroupOrder,
+} from "@/services/demoData";
 
 let pendingGroupsRequest: Promise<GetMyTeamsResponse> | null = null;
 const pendingGroupInfoRequests = new Map<string, Promise<GroupInfo>>();
@@ -46,6 +57,10 @@ export interface GroupRequestDto {
 export const createGroup = async (
   groupData: Omit<GroupRequestDto, "teamId">,
 ) => {
+  if (isDemoMode()) {
+    return createDemoGroup(groupData);
+  }
+
   const requestData: GroupRequestDto = {
     teamId: null,
     ...groupData,
@@ -56,10 +71,26 @@ export const createGroup = async (
 export const joinGroup = async (
   invitationCode: string,
 ): Promise<{ teamId: string; title: string }> => {
+  if (isDemoMode()) {
+    return joinDemoGroup(invitationCode);
+  }
   return post(`/api/teams/join/${invitationCode}`, {});
 };
 
 export const getGroups = async (): Promise<GetMyTeamsResponse> => {
+  if (isDemoMode()) {
+    const demoSelf = getDemoSelfMember();
+    const groups = getDemoGroups().map((group) => ({
+      teamId: group.teamId,
+      title: group.title,
+      memberCount: group.members.length,
+      memberLimit: group.memberLimit,
+      label: group.label,
+      isLeader: group.leaderNickname === demoSelf.nickname,
+    }));
+    return { groups };
+  }
+
   if (pendingGroupsRequest) {
     return pendingGroupsRequest;
   }
@@ -84,6 +115,28 @@ export const getGroups = async (): Promise<GetMyTeamsResponse> => {
 };
 
 export const getGroupInfo = async (teamId: string): Promise<GroupInfo> => {
+  if (isDemoMode()) {
+    const demoSelf = getDemoSelfMember();
+    const target = getDemoGroupInfo(teamId);
+    if (!target) {
+      throw new Error("그룹 정보를 찾을 수 없습니다.");
+    }
+    return {
+      teamId: target.teamId,
+      title: target.title,
+      invitationCode: target.invitationCode,
+      memberLimit: target.memberLimit,
+      purpose: target.purpose,
+      leaderNickname: target.leaderNickname,
+      members: target.members.map((member) => ({
+        nickname: member.nickname,
+        profileImageUrl: member.profileImageUrl,
+      })),
+      label: target.label,
+      isLeader: target.leaderNickname === demoSelf.nickname,
+    };
+  }
+
   const url = `/api/teams/${teamId}`;
 
   if (pendingGroupInfoRequests.has(url)) {
@@ -106,6 +159,16 @@ export const getGroupInfo = async (teamId: string): Promise<GroupInfo> => {
 };
 
 export const updateGroup = async (groupData: GroupRequestDto): Promise<void> => {
+  if (isDemoMode()) {
+    updateDemoGroup({
+      teamId: String(groupData.teamId),
+      title: groupData.title,
+      memberLimit: groupData.memberLimit,
+      purpose: groupData.purpose,
+      label: groupData.label,
+    });
+    return;
+  }
   await patch("/api/teams", groupData);
 };
 
@@ -113,6 +176,11 @@ export const leaveGroup = async (
   teamId: string,
   nextLeaderNickname?: string,
 ): Promise<void> => {
+  if (isDemoMode()) {
+    leaveDemoGroup(teamId, nextLeaderNickname);
+    return;
+  }
+
   try {
     const requestBody = {
       teamId: Number(teamId),
@@ -134,5 +202,9 @@ export interface GroupOrderItem {
 export const updateGroupOrder = async (
   orders: GroupOrderItem[],
 ): Promise<void> => {
+  if (isDemoMode()) {
+    updateDemoGroupOrder(orders);
+    return;
+  }
   await patch("/api/teams/order", { orders });
 };

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -1,5 +1,7 @@
 // services/memberService.ts
-import { get, post, put, del, patch } from "@/utils/apiClient";
+import { get, post, del, patch } from "@/utils/apiClient";
+import { isDemoMode } from "@/utils/demoMode";
+import { getDemoSelfMember } from "@/services/demoData";
 
 // 🔥 중복 요청 방지를 위한 Promise 캐시
 let pendingMemberRequest: Promise<Member> | null = null;
@@ -107,6 +109,21 @@ export const linkSocial = async (data: {
 
 // 회원 조회
 export const getMember = async (): Promise<Member> => {
+  if (isDemoMode()) {
+    const demo = getDemoSelfMember();
+    return {
+      socialTypes: [SocialType.KAKAO],
+      currentLoginSocial: SocialType.KAKAO,
+      email: "demo@dalcoomi.local",
+      name: "체험 사용자",
+      nickname: demo.nickname,
+      birthday: "1998-01-01",
+      gender: "기타",
+      profileImageUrl: demo.profileImageUrl,
+      aiLearningAgreement: false,
+    };
+  }
+
   // 🔥 이미 동일한 요청이 진행 중이면 기존 Promise 반환
   if (pendingMemberRequest) {
     return pendingMemberRequest;

--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -1,5 +1,13 @@
 // services/transactionService.ts
 import { get, post, put, del } from "@/utils/apiClient";
+import { isDemoMode } from "@/utils/demoMode";
+import {
+  addDemoTransaction,
+  deleteDemoTransaction,
+  getDemoTransactionById,
+  getDemoTransactionsByMonth,
+  updateDemoTransaction,
+} from "@/services/demoData";
 
 // 🔥 중복 요청 방지를 위한 Promise 캐시
 const pendingRequests = new Map<string, Promise<MonthlyTransactionsResponse>>();
@@ -56,6 +64,7 @@ export interface TransactionRequest {
   content: string | null;
   transactionDate: string;
   transactionType: "INCOME" | "EXPENSE";
+  synchronizeTransaction?: boolean;
 }
 
 export interface ReceiptsTransactionRequest {
@@ -64,7 +73,11 @@ export interface ReceiptsTransactionRequest {
 }
 
 // 거래 내역 추가 API
-export const addTransaction = async (transactionData: any) => {
+export const addTransaction = async (transactionData: TransactionRequest) => {
+  if (isDemoMode()) {
+    addDemoTransaction(transactionData);
+    return;
+  }
   return post("/api/transactions", transactionData);
 };
 
@@ -72,6 +85,12 @@ export const addTransaction = async (transactionData: any) => {
 export const addReceiptsTransactions = async (
   receiptsData: ReceiptsTransactionRequest
 ) => {
+  if (isDemoMode()) {
+    receiptsData.transactions.forEach((transaction) => {
+      addDemoTransaction(transaction);
+    });
+    return;
+  }
   return post("/api/transactions/receipts/save", receiptsData);
 };
 
@@ -80,6 +99,20 @@ export const uploadReceipt = async (
   file: File,
   teamId?: number | null
 ): Promise<UploadReceiptResponse> => {
+  if (isDemoMode()) {
+    return {
+      taskId: `demo-receipt-${Date.now()}`,
+      transactions: [
+        {
+          transactionDate: new Date().toISOString().slice(0, 19),
+          categoryName: "식비",
+          content: `${file.name.replace(/\.[^.]+$/, "")} 결제`,
+          amount: 12000,
+        },
+      ],
+    };
+  }
+
   try {
     // FormData 생성
     const formData = new FormData();
@@ -139,6 +172,10 @@ export const uploadReceipt = async (
 export const getTransactions = async (
   criteria: TransactionSearchCriteria
 ): Promise<MonthlyTransactionsResponse> => {
+  if (isDemoMode()) {
+    return getDemoTransactionsByMonth(criteria);
+  }
+
   const params = new URLSearchParams();
 
   // teamId 추가 (null이면 개인 거래)
@@ -197,6 +234,14 @@ export const getTransactionById = async (
   transactionId: string,
   teamId?: string
 ): Promise<Transaction> => {
+  if (isDemoMode()) {
+    const found = getDemoTransactionById(transactionId, teamId);
+    if (!found) {
+      throw new Error("거래 내역을 찾을 수 없습니다.");
+    }
+    return found;
+  }
+
   try {
     let url: string;
 
@@ -215,7 +260,14 @@ export const getTransactionById = async (
 };
 
 // 거래 내역 수정
-export const updateTransaction = async (transactionId: string, data: any) => {
+export const updateTransaction = async (
+  transactionId: string,
+  data: TransactionRequest
+) => {
+  if (isDemoMode()) {
+    updateDemoTransaction(transactionId, data);
+    return;
+  }
   return put(`/api/transactions/${transactionId}`, data);
 };
 
@@ -223,5 +275,9 @@ export const updateTransaction = async (transactionId: string, data: any) => {
 export const deleteTransaction = async (
   transactionId: string
 ): Promise<void> => {
+  if (isDemoMode()) {
+    deleteDemoTransaction(transactionId);
+    return;
+  }
   return del(`/api/transactions/${transactionId}`);
 };

--- a/src/stores/useMemberStore.ts
+++ b/src/stores/useMemberStore.ts
@@ -2,6 +2,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { getMember } from "@/services/memberService";
+import { isAuthenticated } from "@/utils/tokenManager";
 
 // 소셜 타입 enum 정의
 export enum SocialType {
@@ -42,8 +43,12 @@ export const useMemberStore = create<MemberStore>()(
       error: null,
 
       fetchMember: async (force = false) => {
-        // force가 true이면 강제로 다시 조회, 그렇지 않으면 이미 회원 정보가 있으면 API 호출하지 않음
-        if (!force && get().member) {
+        const cachedMember = get().member;
+        const hasRealSession = isAuthenticated();
+        const isDemoProfile = cachedMember?.email === "demo@dalcoomi.local";
+
+        // 실제 로그인 상태에서만 기존 캐시를 재사용한다.
+        if (!force && hasRealSession && cachedMember && !isDemoProfile) {
           return;
         }
 

--- a/src/utils/demoMode.ts
+++ b/src/utils/demoMode.ts
@@ -1,0 +1,9 @@
+import { getRefreshToken } from "@/utils/tokenManager";
+
+export const isDemoMode = () => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return !getRefreshToken();
+};


### PR DESCRIPTION
- 비회원 접속 시 체험 데이터 기반 개인/그룹 가계부 플로우를 추가하고 로그인 전환 경로를 정리함
- 체험 모드 상단 배너, 사이드바 접근 제어, PWA 안내 표시 우선순위/겹침 이슈를 수정함
- 개인/그룹 거래내역 통합 필터 바텀시트(정렬/필터/검색)를 개선하고 카테고리 검색 아이콘/간격 규격을 반영함
- 그룹 떠나기 페이지 하단 버튼 레이아웃(떠나기/취소하기)과 여백/스타일 규격을 반영함
