### PR TITLE
release: 그룹 생성 진입 가드와 토스트 표시 동작 수정 등

### DIFF
--- a/src/components/auth/RootPageClient.tsx
+++ b/src/components/auth/RootPageClient.tsx
@@ -39,7 +39,7 @@ export default function RootPageClient({ isLoggedIn }: RootPageClientProps) {
           className="h-full bg-white flex"
           style={{
             width: "100%",
-            maxWidth: isDesktop ? "1000px" : "390px",
+            maxWidth: isDesktop ? "1000px" : "430px",
             boxShadow: isDesktop ? "0 25px 50px -12px rgb(0 0 0 / 0.25)" : "none",
           }}
         >

--- a/src/components/group/CreateGroupPageClient.tsx
+++ b/src/components/group/CreateGroupPageClient.tsx
@@ -1,220 +1,309 @@
-// components/group/CreateGroupPageClient.tsx
 "use client";
-import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+
 import Image from "next/image";
-import { createGroup } from "@/services/groupService";
+import { useRouter } from "next/navigation";
+import { useEffect, useState, type ChangeEvent } from "react";
 import { BRAND_COLORS } from "@/constants/brandColors";
 import BottomButton from "@/components/ui/BottomButton";
+import { createGroup, getGroups } from "@/services/groupService";
 import { useToastStore } from "@/stores/useToastStore";
-// 라벨 컬러 옵션
+
 const LABEL_COLORS = [
   { id: "gray", value: BRAND_COLORS.gray },
   { id: "green", value: BRAND_COLORS.green },
   { id: "blue", value: BRAND_COLORS.blue },
   { id: "red", value: BRAND_COLORS.red },
   { id: "yellow", value: BRAND_COLORS.yellow },
-];
+] as const;
+
+const MIN_MEMBER_LIMIT = 1;
+const MAX_MEMBER_LIMIT = 10;
+const MAX_GROUPS_PER_MEMBER = 3;
+
+const TEXT = {
+  back: "뒤로가기",
+  title: "그룹 생성",
+  groupName: "그룹명",
+  memberLimit: "인원수",
+  labelColor: "라벨 컬러",
+  goal: "목표",
+  memberUnit: "명",
+  memberHelper:
+    "최대 10명까지 가능해요. 이후 수정은 불가능해요.",
+  groupNamePlaceholder: "ex. 2026 오사카 여행",
+  goalPlaceholder: "ex. 하루 10만원으로 여행하기",
+  submit: "그룹 생성하기",
+  submitting: "생성 중..",
+  maxGroupsReached:
+    "이미 최대 3개 그룹에 참여 중이어서 새 그룹을 만들 수 없어요.",
+  error:
+    "그룹 생성 중 오류가 발생했습니다.",
+} as const;
+
+const ICONS = {
+  back: "/images/transaction/v2/뒤로가기_버튼.svg",
+  decreaseEnabled: "/images/transaction/v2/감소_가능.svg",
+  decreaseDisabled: "/images/transaction/v2/감소_불가.svg",
+  increaseEnabled: "/images/transaction/v2/증가_가능.svg",
+  increaseDisabled: "/images/transaction/v2/증가_불가.svg",
+} as const;
+
+function clampMemberLimit(value: number) {
+  return Math.min(MAX_MEMBER_LIMIT, Math.max(MIN_MEMBER_LIMIT, value));
+}
+
 export default function CreateGroupPageClient() {
   const router = useRouter();
   const addToast = useToastStore((state) => state.addToast);
+
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isFormValid, setIsFormValid] = useState(false);
-  // 폼 상태
-  const [title, setTitle] = useState<string>("");
-  const [memberLimit, setMemberLimit] = useState<number>(1);
-  const [selectedColor, setSelectedColor] = useState<string>(
-    LABEL_COLORS[0].id
+  const [title, setTitle] = useState("");
+  const [memberLimit, setMemberLimit] = useState(MIN_MEMBER_LIMIT);
+  const [memberLimitInput, setMemberLimitInput] = useState(
+    String(MIN_MEMBER_LIMIT),
   );
-  const [purpose, setPurpose] = useState<string>("");
-  // 폼 유효성 검사
+  const [selectedColor, setSelectedColor] = useState(LABEL_COLORS[0].id);
+  const [purpose, setPurpose] = useState("");
+
   useEffect(() => {
     setIsFormValid(
-      title.trim().length > 0 && memberLimit >= 1 && memberLimit <= 10
+      title.trim().length > 0 &&
+        memberLimit >= MIN_MEMBER_LIMIT &&
+        memberLimit <= MAX_MEMBER_LIMIT,
     );
   }, [title, memberLimit]);
-  // 그룹명 입력 핸들러
-  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+
+  const handleTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     if (value.length <= 20) {
       setTitle(value);
     }
   };
-  // 멤버수 증가
+
+  const syncMemberLimit = (next: number) => {
+    const clamped = clampMemberLimit(next);
+    setMemberLimit(clamped);
+    setMemberLimitInput(String(clamped));
+  };
+
   const handleIncreaseMember = () => {
-    if (memberLimit < 10) {
-      setMemberLimit((prev) => prev + 1);
-    }
+    syncMemberLimit(memberLimit + 1);
   };
-  // 멤버수 감소
+
   const handleDecreaseMember = () => {
-    if (memberLimit > 1) {
-      setMemberLimit((prev) => prev - 1);
-    }
+    syncMemberLimit(memberLimit - 1);
   };
-  // 목표 입력 핸들러
-  const handlePurposeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+
+  const handleMemberLimitChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const digitsOnly = e.target.value.replace(/\D/g, "").slice(0, 2);
+
+    setMemberLimitInput(digitsOnly);
+
+    if (!digitsOnly) {
+      setMemberLimit(0);
+      return;
+    }
+
+    const parsed = Number(digitsOnly);
+    if (Number.isNaN(parsed)) {
+      setMemberLimit(0);
+      return;
+    }
+
+    setMemberLimit(parsed);
+  };
+
+  const handleMemberLimitBlur = () => {
+    syncMemberLimit(memberLimit);
+  };
+
+  const handlePurposeChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     if (value.length <= 30) {
       setPurpose(value);
     }
   };
-  // 그룹 생성 핸들러
+
   const handleSubmit = async () => {
     if (isSubmitting || !isFormValid) return;
+
     setIsSubmitting(true);
     try {
+      const groupsResponse = await getGroups();
+      const groupCount = groupsResponse.groups?.length ?? 0;
+
+      if (groupCount >= MAX_GROUPS_PER_MEMBER) {
+        addToast("info", TEXT.maxGroupsReached);
+        setIsSubmitting(false);
+        return;
+      }
+
       const groupData = {
         title: title.trim(),
-        memberLimit: memberLimit,
+        memberLimit,
         purpose: purpose.trim() || null,
         label: selectedColor,
       };
-      const response = await createGroup(groupData);
-      const inviteCode = response;
+
+      const inviteCode = await createGroup(groupData);
       router.push(
-        `/group/create/success?code=${inviteCode}&title=${encodeURIComponent(
-          title
-        )}`
+        `/group/create/success?code=${inviteCode}&title=${encodeURIComponent(title)}`,
       );
-    } catch (error: any) {
-      addToast("error", error.message || "그룹 생성 중 오류가 발생했습니다.");
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : TEXT.error;
+      addToast("error", message || TEXT.error);
       setIsSubmitting(false);
     }
   };
+
   return (
-    <div className="flex flex-col h-screen bg-white overflow-hidden">
-      {/* 헤더 */}
+    <div className="flex h-screen flex-col overflow-hidden bg-white">
       <div className="z-50 bg-white">
-        <div className="flex items-center h-[48px] px-0">
+        <div className="flex h-[48px] items-center px-0">
           <button
+            type="button"
             onClick={() => router.back()}
-            className="flex items-center justify-center ml-5 cursor-pointer"
+            className="ml-5 flex cursor-pointer items-center justify-center"
           >
-            <Image
-              src="/images/transaction/v2/뒤로가기_버튼.svg"
-              alt="뒤로가기"
-              width={24}
-              height={24}
-            />
+            <Image src={ICONS.back} alt={TEXT.back} width={24} height={24} />
           </button>
-          <h1 className="ml-3 text-subtitle text-gray-900">그룹 생성</h1>
+          <h1 className="ml-3 text-subtitle text-gray-900">{TEXT.title}</h1>
         </div>
       </div>
-      {/* 폼 내용 */}
-      <div className="flex-1 px-5 pt-6 pb-6 overflow-y-auto scrollbar-hide">
-        {/* 그룹명 */}
+
+      <div className="scrollbar-hide flex-1 overflow-y-auto px-5 pt-6 pb-6">
         <div className="mb-8">
-          <label className="flex items-start gap-1 mb-2 h-[21px]">
-            <span className="text-body2-semibold text-gray-600 leading-[21px]">
-              그룹명
+          <label className="mb-2 flex h-[21px] items-start gap-1">
+            <span className="text-body2-semibold leading-[21px] text-gray-600">
+              {TEXT.groupName}
             </span>
-            <div className="w-1 h-1 rounded-full bg-red-500 mt-1" />
+            <div className="mt-1 h-1 w-1 rounded-full bg-red-500" />
           </label>
           <input
             type="text"
-            className="w-full px-4 py-3 text-body1-regular text-gray-900 placeholder:text-gray-400 bg-white rounded-[12px] border border-gray-100 focus:border-gray-850 focus:outline-none transition-colors"
-            placeholder="ex. 2026 오사카 여행"
+            className="w-full rounded-[12px] border border-gray-100 bg-white px-4 py-3 text-body1-regular text-gray-900 placeholder:text-gray-400 transition-colors focus:border-gray-850 focus:outline-none"
+            placeholder={TEXT.groupNamePlaceholder}
             value={title}
             onChange={handleTitleChange}
             maxLength={20}
           />
         </div>
-        {/* 멤버수 */}
+
         <div className="mb-8">
-          <label className="flex items-start gap-1 mb-2 h-[21px]">
-            <span className="text-body2-semibold text-gray-600 leading-[21px]">
-              멤버수
+          <label className="mb-2 flex h-[21px] items-start gap-1">
+            <span className="text-body2-semibold leading-[21px] text-gray-600">
+              {TEXT.memberLimit}
             </span>
-            <div className="w-1 h-1 rounded-full bg-red-500 mt-1" />
+            <div className="mt-1 h-1 w-1 rounded-full bg-red-500" />
           </label>
-          <div className="flex items-center justify-between w-full px-4 py-3 bg-white rounded-[12px] border border-gray-100">
+          <div className="flex w-full items-center justify-between rounded-[12px] border border-gray-100 bg-white px-4 py-3">
             <button
+              type="button"
               onClick={handleDecreaseMember}
-              disabled={memberLimit <= 1}
-              className="flex items-center justify-center w-5 h-5 cursor-pointer disabled:cursor-not-allowed"
+              disabled={memberLimit <= MIN_MEMBER_LIMIT}
+              className="flex h-5 w-5 cursor-pointer items-center justify-center disabled:cursor-not-allowed"
             >
               <Image
-                src={`/images/transaction/v2/감소_${
-                  memberLimit <= 1 ? "불가" : "가능"
-                }.svg`}
-                alt="감소"
+                src={
+                  memberLimit <= MIN_MEMBER_LIMIT
+                    ? ICONS.decreaseDisabled
+                    : ICONS.decreaseEnabled
+                }
+                alt="-"
                 width={20}
                 height={20}
               />
             </button>
-            <span className="text-body1-regular text-gray-900">
-              {memberLimit}명
-            </span>
+
+            <div className="flex items-baseline gap-[2px]">
+              <input
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                value={memberLimitInput}
+                onChange={handleMemberLimitChange}
+                onBlur={handleMemberLimitBlur}
+                className="w-[2ch] min-w-[20px] bg-transparent text-right text-body1-regular text-gray-900 outline-none"
+              />
+              <span className="text-body1-regular text-gray-900">
+                {TEXT.memberUnit}
+              </span>
+            </div>
+
             <button
+              type="button"
               onClick={handleIncreaseMember}
-              disabled={memberLimit >= 10}
-              className="flex items-center justify-center w-5 h-5 cursor-pointer disabled:cursor-not-allowed"
+              disabled={memberLimit >= MAX_MEMBER_LIMIT}
+              className="flex h-5 w-5 cursor-pointer items-center justify-center disabled:cursor-not-allowed"
             >
               <Image
-                src={`/images/transaction/v2/증가_${
-                  memberLimit >= 10 ? "불가" : "가능"
-                }.svg`}
-                alt="증가"
+                src={
+                  memberLimit >= MAX_MEMBER_LIMIT
+                    ? ICONS.increaseDisabled
+                    : ICONS.increaseEnabled
+                }
+                alt="+"
                 width={20}
                 height={20}
               />
             </button>
           </div>
-          <p className="mt-2 text-caption1-medium text-gray-400 text-left">
-            최대 10명까지 가능해요. 이후 수정은 불가능해요.
+          <p className="mt-2 text-left text-caption1-medium text-gray-400">
+            {TEXT.memberHelper}
           </p>
         </div>
-        {/* 라벨 컬러 */}
+
         <div className="mb-8">
-          <label className="flex items-start gap-1 mb-2 h-[21px]">
-            <span className="text-body2-semibold text-gray-600 leading-[21px]">
-              라벨 컬러
+          <label className="mb-2 flex h-[21px] items-start gap-1">
+            <span className="text-body2-semibold leading-[21px] text-gray-600">
+              {TEXT.labelColor}
             </span>
-            <div className="w-1 h-1 rounded-full bg-red-500 mt-1" />
+            <div className="mt-1 h-1 w-1 rounded-full bg-red-500" />
           </label>
           <div className="flex items-center gap-4">
             {LABEL_COLORS.map((color) => (
               <button
                 key={color.id}
+                type="button"
                 onClick={() => setSelectedColor(color.id)}
-                className={`flex items-center justify-center w-[44px] h-[44px] rounded-full cursor-pointer ${
+                className={`flex h-[44px] w-[44px] cursor-pointer items-center justify-center rounded-full ${
                   selectedColor === color.id
                     ? "border-2 border-gray-900"
                     : "border border-gray-100"
                 }`}
               >
                 <div
-                  className="w-[36px] h-[36px] rounded-full"
+                  className="h-[36px] w-[36px] rounded-full"
                   style={{ backgroundColor: color.value }}
                 />
               </button>
             ))}
           </div>
         </div>
-        {/* 목표 */}
+
         <div>
-          <label className="flex items-start gap-1 mb-2 h-[21px]">
-            <span className="text-body2-semibold text-gray-600 leading-[21px]">
-              목표
+          <label className="mb-2 flex h-[21px] items-start gap-1">
+            <span className="text-body2-semibold leading-[21px] text-gray-600">
+              {TEXT.goal}
             </span>
           </label>
           <input
             type="text"
-            className="w-full px-4 py-3 text-body1-regular text-gray-900 placeholder:text-gray-400 bg-white rounded-[12px] border border-gray-100 focus:border-gray-850 focus:outline-none transition-colors"
-            placeholder="ex. 하루 10만원으로 여행하기"
+            className="w-full rounded-[12px] border border-gray-100 bg-white px-4 py-3 text-body1-regular text-gray-900 placeholder:text-gray-400 transition-colors focus:border-gray-850 focus:outline-none"
+            placeholder={TEXT.goalPlaceholder}
             value={purpose}
             onChange={handlePurposeChange}
             maxLength={30}
           />
         </div>
       </div>
-      {/* 하단 고정 버튼 */}
+
       <BottomButton
-        text={isSubmitting ? "생성 중..." : "그룹 생성하기"}
+        text={isSubmitting ? TEXT.submitting : TEXT.submit}
         onClick={handleSubmit}
         disabled={!isFormValid || isSubmitting}
-        className="pb-4" 
+        className="pb-4"
       />
     </div>
   );

--- a/src/components/transaction/common/CategorySelectionModalContent.tsx
+++ b/src/components/transaction/common/CategorySelectionModalContent.tsx
@@ -17,16 +17,15 @@ interface CategorySelectionModalContentProps {
 }
 
 const TEXT = {
-  title: "\uCE74\uD14C\uACE0\uB9AC",
-  searchAlt: "\uAC80\uC0C9",
-  searchPlaceholder: "\uCE74\uD14C\uACE0\uB9AC \uAC80\uC0C9",
-  loading: "\uCE74\uD14C\uACE0\uB9AC \uBD88\uB7EC\uC624\uB294 \uC911...",
-  empty: "\uAC80\uC0C9 \uACB0\uACFC\uAC00 \uC5C6\uC5B4\uC694.",
-  add: "\uCD94\uAC00",
+  title: "카테고리",
+  searchAlt: "검색",
+  searchPlaceholder: "카테고리 검색",
+  loading: "카테고리 불러오는 중...",
+  empty: "검색 결과가 없어요.",
+  add: "추가",
 } as const;
 
-const SEARCH_ICON_SRC =
-  "/images/transaction/v2/\uB3CB\uBCF4\uAE30_\uD68C\uC0C9.svg";
+const SEARCH_ICON_SRC = "/images/transaction/v2/돋보기_회색.svg";
 
 export default function CategorySelectionModalContent({
   categories,

--- a/src/components/transaction/group/GroupTransactionPageClient.tsx
+++ b/src/components/transaction/group/GroupTransactionPageClient.tsx
@@ -42,6 +42,9 @@ import DemoModeTopBanner from "@/components/common/DemoModeTopBanner";
 import { isDemoMode } from "@/utils/demoMode";
 
 let cachedGroupModalList: Group[] = [];
+const MAX_GROUPS_PER_MEMBER = 3;
+const MAX_GROUPS_REACHED_MESSAGE =
+  "이미 최대 3개 그룹에 참여 중이어서 새 그룹을 만들 수 없어요.";
 
 export default function GroupTransactionPageClient() {
   const router = useRouter();
@@ -201,6 +204,10 @@ export default function GroupTransactionPageClient() {
 
       const groupsResponse = await getGroups();
       const myGroups = groupsResponse.groups ?? [];
+      if (!isCancelled) {
+        cachedGroupModalList = myGroups;
+        setGroups(myGroups);
+      }
       const isMemberOfTeam = myGroups.some(
         (group) => String(group.teamId) === String(teamId),
       );
@@ -721,8 +728,18 @@ export default function GroupTransactionPageClient() {
     router.push("/group/join");
   };
 
-  const handleCreateGroup = () => {
+  const handleCreateGroup = async (): Promise<boolean> => {
+    const knownGroups =
+      groups.length > 0 ? groups : cachedGroupModalList;
+    const groupCount = knownGroups.length;
+
+    if (groupCount >= MAX_GROUPS_PER_MEMBER) {
+      addToast("info", MAX_GROUPS_REACHED_MESSAGE);
+      return false;
+    }
+
     router.push("/group/create");
+    return true;
   };
 
   const handleCloseGroupModal = () => {
@@ -815,8 +832,12 @@ export default function GroupTransactionPageClient() {
         const nextGroups = response.groups || [];
         cachedGroupModalList = nextGroups;
         setGroups(nextGroups);
-      } catch {
-        addToast("error", "그룹 목록을 불러오지 못했습니다.");
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "그룹 목록을 불러오지 못했습니다.";
+        addToast("error", message);
       }
     };
 
@@ -1042,9 +1063,11 @@ export default function GroupTransactionPageClient() {
             </div>
 
             <button
-              onClick={() => {
-                setShowGroupModal(false);
-                handleCreateGroup();
+              onClick={async () => {
+                const canNavigate = await handleCreateGroup();
+                if (canNavigate) {
+                  setShowGroupModal(false);
+                }
               }}
               className="w-full h-12 px-5 py-3 rounded-[100px] bg-gray-50 border border-gray-100 cursor-pointer mb-2 flex items-center justify-center gap-2"
             >

--- a/src/components/ui/ToastContainer.tsx
+++ b/src/components/ui/ToastContainer.tsx
@@ -50,9 +50,10 @@ function ToastItem({
 
   return (
     <div
-      className="col-start-1 row-start-1 flex max-w-[calc(100vw-40px)] md:max-w-[420px] items-center min-h-12 bg-white rounded-full pl-3 pr-5 py-3 shadow-lg transition-all duration-300 ease-out pointer-events-auto"
+      className="col-start-1 row-start-1 flex w-fit items-center min-h-12 bg-white rounded-full pl-3 pr-5 py-3 shadow-lg transition-all duration-300 ease-out pointer-events-auto"
       style={{
         zIndex: total - reverseIndex,
+        maxWidth: "min(420px, calc(100vw - 16px))",
         transform:
           isVisible && !isLeaving
             ? `translateY(${offset}px) scale(${scale})`
@@ -67,7 +68,7 @@ function ToastItem({
         height={24}
         className="shrink-0"
       />
-      <span className="ml-2 min-w-0 break-words whitespace-normal md:whitespace-nowrap text-body1-semibold text-gray-900">
+      <span className="ml-2 flex-1 min-w-0 whitespace-normal break-words [overflow-wrap:anywhere] text-body1-semibold text-gray-900">
         {toast.message}
       </span>
     </div>
@@ -80,7 +81,7 @@ export default function ToastContainer() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className="absolute top-12 left-1/2 -translate-x-1/2 z-9999 grid place-items-center pointer-events-none">
+    <div className="absolute top-12 inset-x-0 z-9999 grid place-items-center px-2 pointer-events-none">
       {toasts.map((toast, index) => (
         <ToastItem
           key={toast.id}

--- a/src/services/groupService.ts
+++ b/src/services/groupService.ts
@@ -100,7 +100,11 @@ export const getGroups = async (): Promise<GetMyTeamsResponse> => {
       const response = await get("/api/teams");
       return response;
     } catch (error) {
-      useToastStore.getState().addToast("error", String(error));
+      const message =
+        error instanceof Error
+          ? error.message
+          : "그룹 목록을 불러오지 못했습니다.";
+      useToastStore.getState().addToast("error", message);
       return {
         groups: [],
       };


### PR DESCRIPTION
- 그룹 생성 API 실패 시 백엔드 응답 에러 메시지를 토스트에 노출하도록 변경
- 바텀시트 그룹 생성 버튼은 프론트 상태 기준으로 최대 그룹 수를 검사하도록 조정
- 토스트 너비를 콘텐츠 기반으로 조정해 짧은 문구의 과도한 가로 확장을 제거
- 그룹/카테고리 관련 화면 문구와 표시를 한국어 기준으로 정리
